### PR TITLE
Add autoconf to BuildRequires

### DIFF
--- a/erlang.spec
+++ b/erlang.spec
@@ -46,6 +46,7 @@ BuildRequires:	ncurses-devel
 BuildRequires:	openssl-devel
 BuildRequires:	zlib-devel
 BuildRequires:	m4
+BuildRequires:	autoconf
 
 Obsoletes: erlang-docbuilder
 Provides: erlang


### PR DESCRIPTION
When building with mock, autoconf is not available in the `epel-7-x86_64` chroot unless specified as a BuildRequires.

Here are the commands I used:

```
$ git clone https://github.com/rabbitmq/erlang-rpm.git
$ cd erlang-rpm
$ curl -LO https://github.com/erlang/otp/archive/OTP-19.3.2.tar.gz
$ sudo mock -r epel-7-x86_64 --resultdir=results --spec=./erlang.spec --sources=. --buildsrpm
$ sudo mock -r epel-7-x86_64 --sources=. --resultdir=results/ --rebuild results/erlang-19.3.2-1.el7.centos.src.rpm
```

Here is the error I was seeing before making this change: https://gist.github.com/shanemcd/d4da475611ca68cdb665a353d43bfb1a