### PR TITLE
Fix Concourse build adding package_ver_release

### DIFF
--- a/erlang.spec
+++ b/erlang.spec
@@ -12,8 +12,8 @@
 # under the License.
 
 %global upstream_ver 19.3.6.1
-%global package_ver  19.3.6
-%global package_ver_release 1.1
+%global package_ver  19.3.6.1
+%global package_ver_release 1
 
 %define OSL_File_Name                   Erlang_ASL2_LICENSE.txt
 

--- a/erlang.spec
+++ b/erlang.spec
@@ -13,7 +13,7 @@
 
 %global upstream_ver 19.3.6.1
 %global package_ver  19.3.6
-%global package_ver_release 1
+%global package_ver_release 1.1
 
 %define OSL_File_Name                   Erlang_ASL2_LICENSE.txt
 


### PR DESCRIPTION
Fix Concourse build adding package_ver_release.

output package name `erlang-19.3.6.1-1.el7.centos.x86_64.rpm` 