### PR TITLE
Add Crypto patch for EC_GROUP_new_curve_GF2m

### DIFF
--- a/erlang.spec
+++ b/erlang.spec
@@ -38,7 +38,8 @@ Patch2: otp-0002-Remove-rpath.patch
 Patch3: otp-0003-Do-not-install-C-sources.patch
 #   Do not install erlang sources
 Patch7: otp-0007-Do-not-install-erlang-sources.patch
-
+#   crypto patch
+Patch8: otp-0008-crypto.patch
 
 # BuildRoot not strictly needed since F10, but keep it for spec file robustness
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
@@ -71,6 +72,8 @@ syntax_tools and xmerl.
 %patch2 -p1 -b .Remove_rpath
 %patch3 -p1 -b .Do_not_install_C_sources
 %patch7 -p1 -F1 -b .Do_not_install_erlang_sources
+%patch8 -p1 -b .Crypto
+
 
 # remove shipped zlib sources
 # commented out because centos only has 1.2.3 and Erlang 18.1 needs a later version
@@ -331,6 +334,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Tue Nov 6 2018 Gabriele Santomaggio <g.santomaggio@gmil.com> 
+- Add patch file for crypo.c
+
 * Wed Oct 24 2018 Michael Klishin <mklishin@pivotal.io> - 21.1.1
 - Update to Erlang/OTP 21.1.1.
 

--- a/otp-0002-Remove-rpath.patch
+++ b/otp-0002-Remove-rpath.patch
@@ -1,7 +1,7 @@
-diff -u -r otp_src_18.3-a/lib/crypto/c_src/Makefile.in otp_src_18.3/lib/crypto/c_src/Makefile.in
---- otp_src_18.3-a/lib/crypto/c_src/Makefile.in	2014-12-09 20:11:07.000000000 +0000
-+++ otp_src_18.3/lib/crypto/c_src/Makefile.in	2015-01-14 12:45:52.181287995 +0000
-@@ -89,7 +89,7 @@
+diff -u -r otp-OTP-21.1.1.orig/lib/crypto/c_src/Makefile.in otp-OTP-21.1.1/lib/crypto/c_src/Makefile.in
+--- otp-OTP-21.1.1.orig/lib/crypto/c_src/Makefile.in	2018-10-12 17:12:11.000000000 +0200
++++ otp-OTP-21.1.1/lib/crypto/c_src/Makefile.in	2018-11-02 16:59:43.766304768 +0100
+@@ -96,7 +96,7 @@
  DYNAMIC_CRYPTO_LIB=@SSL_DYNAMIC_ONLY@
  
  ifeq ($(DYNAMIC_CRYPTO_LIB),yes)
@@ -10,10 +10,10 @@ diff -u -r otp_src_18.3-a/lib/crypto/c_src/Makefile.in otp_src_18.3/lib/crypto/c
  CRYPTO_LINK_LIB=$(SSL_DED_LD_RUNTIME_LIBRARY_PATH) -L$(SSL_LIBDIR) -l$(SSL_CRYPTO_LIBNAME)
  EXTRA_FLAGS = -DHAVE_DYNAMIC_CRYPTO_LIB
  else
-diff -u -r otp_src_18.3-a/lib/crypto/priv/Makefile otp_src_18.3/lib/crypto/priv/Makefile
---- otp_src_18.3-a/lib/crypto/priv/Makefile	2014-12-09 20:11:07.000000000 +0000
-+++ otp_src_18.3/lib/crypto/priv/Makefile	2015-01-14 12:45:52.181287995 +0000
-@@ -60,7 +60,7 @@
+diff -u -r otp-OTP-21.1.1.orig/lib/crypto/priv/Makefile otp-OTP-21.1.1/lib/crypto/priv/Makefile
+--- otp-OTP-21.1.1.orig/lib/crypto/priv/Makefile	2018-10-12 17:12:11.000000000 +0200
++++ otp-OTP-21.1.1/lib/crypto/priv/Makefile	2018-11-02 17:01:23.294304768 +0100
+@@ -61,7 +61,7 @@
  # ----------------------------------------------------
  
  $(SO_NIFLIB): $(OBJS)

--- a/otp-0008-crypto.patch
+++ b/otp-0008-crypto.patch
@@ -1,0 +1,13 @@
+diff -u -r otp-OTP-21.1.1.orig/lib/crypto/c_src/crypto.c otp-OTP-21.1.1/lib/crypto/c_src/crypto.c 
+--- otp-OTP-21.1.1.orig/lib/crypto/c_src/crypto.c	2018-10-12 17:12:11.000000000 +0200
++++ otp-OTP-21.1.1/lib/crypto/c_src/crypto.c	2018-11-02 15:42:24.274260763 +0100
+@@ -168,7 +168,8 @@
+ #if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION(0,9,8,'o') \
+ 	&& !defined(OPENSSL_NO_EC) \
+ 	&& !defined(OPENSSL_NO_ECDH) \
+-	&& !defined(OPENSSL_NO_ECDSA)
++	&& !defined(OPENSSL_NO_ECDSA) \
++	&& !defined(OPENSSL_NO_EC2M)
+ # define HAVE_EC
+ #endif
+ 


### PR DESCRIPTION

In openssl 1.0.1e `EC_GROUP_new_curve_GF2m` function is wrapped by #ifndef `OPENSSL_NO_EC2M`.
We have to check whether `OPENSSL_NO_EC2M` is set, and if it is, then we do not have `EC_GROUP_new_curve_GF2m` function and do not `HAVE_EC`.

Currecntly there is kind of the problem:
```
Erlang/OTP 21 [erts-10.1.1] [source] [64-bit] [smp:2:2] [ds:2:2:10] [async-threads:1] [hipe]

Eshell V10.1.1  (abort with ^G)
1> l(crypto).
{module,crypto}
2> crypto:generate_key(ecdh, secp112r2).
** exception error: bad argument
     in function  crypto:ec_key_generate/2
        called as crypto:ec_key_generate({{prime_field,<<219,124,42,191,98,227,94,102,128,118,190,173,32,139>>},{<<97,39,194,76,5,243,138,10,170,246,92,14,240,44>>,
                             <<81,222,241,129,93,181,237,116,252,195,76,133,215,9>>,
                    <<0,39,87,161,17,77,105,110,103,104,117,97,81,117,83,22,192,94,11,212>>},<<4,75,163,10,181,232,146,180,225,100,157,208,146,134,67,173,205,70,245,136,46,55,71,222,243,...>>,
                            <<54,223,10,175,216,184,215,89,124,161,5,32,208,75>>,<<4>>},
                                         undefined)
3>
```

I remember that we met this problem before.

With this patch the result will be:
```
Eshell V10.1.1  (abort with ^G)
1>  crypto:generate_key(ecdh, secp112r2).
notsup
2>
```

**Notes:**
1 - Copied from https://build.opensuse.org/package/view_file/devel:languages:erlang:Factory/erlang/crypto.patch?expand=1&rev=92106653f72b30973f28170277fa4b0e 
2 - also in the last [release](https://build.opensuse.org/package/view_file/devel:languages:erlang/erlang/crypto.patch?expand=1)
3- Even if there is a way, to enable [Enable Elliptical Curve Diffie-Hellman (ECDHE) in Linux](https://www.internetstaff.com/enable-elliptical-curve-diffie-hellman-ecdhe-linux/
), I think that it shouldn't be done :)
