### PR TITLE
Porting https://github.com/rabbitmq/erlang-rpm/pull/65 for erlang 19.x

### DIFF
--- a/erlang.spec
+++ b/erlang.spec
@@ -38,6 +38,8 @@ Patch2: otp-0002-Remove-rpath.patch
 Patch3: otp-0003-Do-not-install-C-sources.patch
 #   Do not install erlang sources
 Patch7: otp-0007-Do-not-install-erlang-sources.patch
+#   Crypto patch
+Patch8: otp-0008-crypto.patch
 
 
 # BuildRoot not strictly needed since F10, but keep it for spec file robustness
@@ -71,6 +73,7 @@ syntax_tools and xmerl.
 %patch2 -p1 -b .Remove_rpath
 %patch3 -p1 -b .Do_not_install_C_sources
 %patch7 -p1 -b .Do_not_install_erlang_sources
+%patch8 -p1 -b .Crypto
 
 # remove shipped zlib sources
 # commented out because centos only has 1.2.3 and Erlang 18.1 needs a later version

--- a/otp-0002-Remove-rpath.patch
+++ b/otp-0002-Remove-rpath.patch
@@ -1,19 +1,17 @@
-diff -u -r otp_src_18.3-a/lib/crypto/c_src/Makefile.in otp_src_18.3/lib/crypto/c_src/Makefile.in
---- otp_src_18.3-a/lib/crypto/c_src/Makefile.in	2014-12-09 20:11:07.000000000 +0000
-+++ otp_src_18.3/lib/crypto/c_src/Makefile.in	2015-01-14 12:45:52.181287995 +0000
-@@ -89,7 +89,7 @@
+--- otp-OTP-19.3.6.12.orig/lib/crypto/c_src/Makefile.in	2018-11-07 15:56:33.000000000 +0100
++++ otp-OTP-19.3.6.12/lib/crypto/c_src/Makefile.in	2018-11-07 16:03:41.000000000 +0100
+@@ -90,7 +90,7 @@
  DYNAMIC_CRYPTO_LIB=@SSL_DYNAMIC_ONLY@
  
  ifeq ($(DYNAMIC_CRYPTO_LIB),yes)
 -SSL_DED_LD_RUNTIME_LIBRARY_PATH = @SSL_DED_LD_RUNTIME_LIBRARY_PATH@
-+SSL_DED_LD_RUNTIME_LIBRARY_PATH =
++SSL_DED_LD_RUNTIME_LIBRARY_PATH = 
  CRYPTO_LINK_LIB=$(SSL_DED_LD_RUNTIME_LIBRARY_PATH) -L$(SSL_LIBDIR) -l$(SSL_CRYPTO_LIBNAME)
  EXTRA_FLAGS = -DHAVE_DYNAMIC_CRYPTO_LIB
  else
-diff -u -r otp_src_18.3-a/lib/crypto/priv/Makefile otp_src_18.3/lib/crypto/priv/Makefile
---- otp_src_18.3-a/lib/crypto/priv/Makefile	2014-12-09 20:11:07.000000000 +0000
-+++ otp_src_18.3/lib/crypto/priv/Makefile	2015-01-14 12:45:52.181287995 +0000
-@@ -60,7 +60,7 @@
+--- otp-OTP-19.3.6.12.orig/lib/crypto/priv/Makefile	2018-11-07 15:56:33.000000000 +0100
++++ otp-OTP-19.3.6.12/lib/crypto/priv/Makefile	2018-11-07 16:04:41.000000000 +0100
+@@ -61,7 +61,7 @@
  # ----------------------------------------------------
  
  $(SO_NIFLIB): $(OBJS)

--- a/otp-0008-crypto.patch
+++ b/otp-0008-crypto.patch
@@ -1,0 +1,12 @@
+--- otp-OTP-19.3.6.12.orig/lib/crypto/c_src/crypto.c	2018-11-07 15:56:33.000000000 +0100
++++ otp-OTP-19.3.6.12/lib/crypto/c_src/crypto.c	2018-11-07 16:01:02.000000000 +0100
+@@ -102,7 +102,8 @@
+ #if OPENSSL_VERSION_NUMBER >= OpenSSL_version(0,9,8,'o') \
+ 	&& !defined(OPENSSL_NO_EC) \
+ 	&& !defined(OPENSSL_NO_ECDH) \
+-	&& !defined(OPENSSL_NO_ECDSA)
++	&& !defined(OPENSSL_NO_ECDSA) \
++    && !defined(OPENSSL_NO_EC2M)
+ # define HAVE_EC
+ #endif
+ 


### PR DESCRIPTION
Porting https://github.com/rabbitmq/erlang-rpm/pull/65 for erlang 19.x

```
Erlang/OTP 19 [erts-8.3.5.6] [source] [64-bit] [smp:2:2] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.3.5.6  (abort with ^G)
1> crypto:generate_key(ecdh, secp112r2).
notsup
2>
```
