### PR TITLE
Porting https://github.com/rabbitmq/erlang-rpm/pull/65 for erlang 20.3.x

### DIFF
--- a/erlang.spec
+++ b/erlang.spec
@@ -38,7 +38,8 @@ Patch2: otp-0002-Remove-rpath.patch
 Patch3: otp-0003-Do-not-install-C-sources.patch
 #   Do not install erlang sources
 Patch7: otp-0007-Do-not-install-erlang-sources.patch
-
+#   Crypto patch
+Patch8: otp-0008-crypto.patch
 
 # BuildRoot not strictly needed since F10, but keep it for spec file robustness
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
@@ -71,7 +72,7 @@ syntax_tools and xmerl.
 %patch2 -p1 -b .Remove_rpath
 %patch3 -p1 -b .Do_not_install_C_sources
 %patch7 -p1 -b .Do_not_install_erlang_sources
-
+%patch8 -p1 -b .Crypto
 # remove shipped zlib sources
 # commented out because centos only has 1.2.3 and Erlang 18.1 needs a later version
 #rm -f erts/emulator/zlib/*.[ch]

--- a/otp-0002-Remove-rpath.patch
+++ b/otp-0002-Remove-rpath.patch
@@ -1,7 +1,7 @@
-diff -u -r otp_src_18.3-a/lib/crypto/c_src/Makefile.in otp_src_18.3/lib/crypto/c_src/Makefile.in
---- otp_src_18.3-a/lib/crypto/c_src/Makefile.in	2014-12-09 20:11:07.000000000 +0000
-+++ otp_src_18.3/lib/crypto/c_src/Makefile.in	2015-01-14 12:45:52.181287995 +0000
-@@ -89,7 +89,7 @@
+diff -u  otp-OTP-20.3.8.10.orig/lib/crypto/c_src/Makefile.in  otp-OTP-20.3.8.10/lib/crypto/c_src/Makefile.in
+--- otp-OTP-20.3.8.10.orig/lib/crypto/c_src/Makefile.in	2018-11-07 21:53:47.000000000 +0100
++++ otp-OTP-20.3.8.10/lib/crypto/c_src/Makefile.in	2018-11-07 22:04:18.000000000 +0100
+@@ -96,7 +96,7 @@
  DYNAMIC_CRYPTO_LIB=@SSL_DYNAMIC_ONLY@
  
  ifeq ($(DYNAMIC_CRYPTO_LIB),yes)
@@ -10,15 +10,16 @@ diff -u -r otp_src_18.3-a/lib/crypto/c_src/Makefile.in otp_src_18.3/lib/crypto/c
  CRYPTO_LINK_LIB=$(SSL_DED_LD_RUNTIME_LIBRARY_PATH) -L$(SSL_LIBDIR) -l$(SSL_CRYPTO_LIBNAME)
  EXTRA_FLAGS = -DHAVE_DYNAMIC_CRYPTO_LIB
  else
-diff -u -r otp_src_18.3-a/lib/crypto/priv/Makefile otp_src_18.3/lib/crypto/priv/Makefile
---- otp_src_18.3-a/lib/crypto/priv/Makefile	2014-12-09 20:11:07.000000000 +0000
-+++ otp_src_18.3/lib/crypto/priv/Makefile	2015-01-14 12:45:52.181287995 +0000
-@@ -60,7 +60,7 @@
+
+diff -u  otp-OTP-20.3.8.10.orig/lib/crypto/priv/Makefile otp-OTP-20.3.8.10/lib/crypto/priv/Makefile
+--- otp-OTP-20.3.8.10.orig/lib/crypto/priv/Makefile	2018-11-07 21:53:47.000000000 +0100
++++ otp-OTP-20.3.8.10/lib/crypto/priv/Makefile	2018-11-07 22:07:14.000000000 +0100
+@@ -61,7 +61,7 @@
  # ----------------------------------------------------
  
  $(SO_NIFLIB): $(OBJS)
 -	$(SO_LD) $(SO_LDFLAGS) -L$(SO_SSL_LIBDIR) -Wl,-R$(SO_SSL_LIBDIR) \
-+	$(SO_LD) $(SO_LDFLAGS) -L$(SO_SSL_LIBDIR) \
++	$(SO_LD) $(SO_LDFLAGS) -L$(SO_SSL_LIBDIR) \ 
  	-o $@ $^ -lcrypto
  
  $(DLL_NIFLIB): $(OBJS)

--- a/otp-0008-crypto.patch
+++ b/otp-0008-crypto.patch
@@ -1,0 +1,13 @@
+ diff -u -r otp-OTP-20.3.8.10.orig/lib/crypto/c_src/crypto.c  otp-OTP-20.3.8.10/lib/crypto/c_src/crypto.c 
+--- otp-OTP-20.3.8.10.orig/lib/crypto/c_src/crypto.c	2018-11-07 21:53:47.000000000 +0100
++++ otp-OTP-20.3.8.10/lib/crypto/c_src/crypto.c	2018-11-07 21:57:30.000000000 +0100
+@@ -151,7 +151,8 @@
+ #if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION(0,9,8,'o') \
+ 	&& !defined(OPENSSL_NO_EC) \
+ 	&& !defined(OPENSSL_NO_ECDH) \
+-	&& !defined(OPENSSL_NO_ECDSA)
++	&& !defined(OPENSSL_NO_ECDSA) \
++    && !defined(OPENSSL_NO_EC2M)
+ # define HAVE_EC
+ #endif
+ 


### PR DESCRIPTION
Porting https://github.com/rabbitmq/erlang-rpm/pull/65 for erlang 20.3.x

```
Erlang/OTP 20 [erts-9.3.3.4] [source] [64-bit] [smp:2:2] [ds:2:2:10] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V9.3.3.4  (abort with ^G)
1> crypto:generate_key(ecdh, secp112r2).
notsup
2>
```