### PR TITLE
URL Cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The process is fairly standard:
  * Fork the repository or repositories you plan on contributing to
  * Clone it
  * Create a branch with a descriptive name in the relevant repositories
- * Make your changes, run tests, commit with a [descriptive message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
+ * Make your changes, run tests, commit with a [descriptive message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
  * Submit pull requests with an explanation what has been changed and **why**
  * Submit a filled out and signed [Contributor Agreement](https://github.com/rabbitmq/ca#how-to-submit) if needed (see below)
  * Be patient. We will get to your pull request eventually

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Version 1.1, (the "License"); you may not use this file except in
 # compliance with the License. You should have received a copy of the
 # Erlang Public License along with this software. If not, it can be
-# retrieved online at http://www.erlang.org/.
+# retrieved online at https://www.erlang.org/.
 #
 # Software distributed under the License is distributed on an "AS IS"
 # basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Team RabbitMQ also packages [recent Erlang/OTP releases for Debian](https://gith
 
 The package currently targets Erlang/OTP `21.x`, `20.3.x`, `19.3.x`. Only 64-bit packages are provided.
 
-Some earlier releases are available but [highly discouraged](http://www.rabbitmq.com/which-erlang.html) due to known
+Some earlier releases are available but [highly discouraged](https://www.rabbitmq.com/which-erlang.html) due to known
 bugs that are catastrophic to RabbitMQ.
 
 

--- a/erlang.spec
+++ b/erlang.spec
@@ -4,7 +4,7 @@
 # Version 1.1, (the "License"); you may not use this file except in
 # compliance with the License. You should have received a copy of the
 # Erlang Public License along with this software. If not, it can be
-# retrieved online at http://www.erlang.org/.
+# retrieved online at https://www.erlang.org/.
 #
 # Software distributed under the License is distributed on an "AS IS"
 # basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
@@ -24,7 +24,7 @@ Summary:	General-purpose programming language and runtime environment
 
 Group:		Development/Languages
 License:	ERPL
-URL:		http://www.erlang.org
+URL:		https://www.erlang.org
 Source0:	https://github.com/erlang/otp/archive/OTP-%{upstream_ver}.tar.gz
 Source2:        %{OSL_File_Name}
 Vendor:		Pivotal Software, Inc.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* http://www.erlang.org with 1 occurrences migrated to:  
  https://www.erlang.org ([https](https://www.erlang.org) result 200).
* http://www.erlang.org/ with 2 occurrences migrated to:  
  https://www.erlang.org/ ([https](https://www.erlang.org/) result 200).
* http://www.rabbitmq.com/which-erlang.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/which-erlang.html ([https](https://www.rabbitmq.com/which-erlang.html) result 200).