### PR TITLE
Enable systemd for EPMD

### DIFF
--- a/erlang.spec
+++ b/erlang.spec
@@ -92,8 +92,11 @@ chmod 644 lib/ssl/examples/src/Makefile
 
 
 %build
+%if ! (0%{?rhel} && 0%{?rhel} <= 6)
 %global conf_flags --enable-shared-zlib --enable-systemd --without-javac --without-odbc
-
+%else
+%global conf_flags --enable-shared-zlib --without-javac --without-odbc
+%endif
 
 # autoconf
 ./otp_build autoconf

--- a/erlang.spec
+++ b/erlang.spec
@@ -47,6 +47,13 @@ BuildRequires:	openssl-devel
 BuildRequires:	zlib-devel
 BuildRequires:	m4
 BuildRequires:	autoconf
+%if ! (0%{?rhel} && 0%{?rhel} <= 6)
+BuildRequires:	systemd-devel
+BuildRequires:	systemd
+%{?systemd_requires}
+Requires:	systemd
+%endif
+
 
 Obsoletes: erlang-docbuilder
 
@@ -85,7 +92,7 @@ chmod 644 lib/ssl/examples/src/Makefile
 
 
 %build
-%global conf_flags --enable-shared-zlib --without-javac --without-odbc
+%global conf_flags --enable-shared-zlib --enable-systemd --without-javac --without-odbc
 
 
 # autoconf


### PR DESCRIPTION
[ group thread ](https://groups.google.com/d/msg/rabbitmq-users/r8C5wttXWRA/3Nm7ciyZEQAJ)

This PR enables the build with the `--enable-systemd `

Currently[ SUSE](https://build.opensuse.org/package/view_file/devel:languages:erlang:Factory/erlang/erlang.spec?expand=1) and [Fedora]( https://koji.fedoraproject.org/koji/buildinfo?buildID=1323226) by defualt enable the systemd option
In this way it is possible to run the epmd in different cgropus and interact with [systemd activation socket](https://github.com/erlang/otp/pull/204) 


**Don't merge yet,** the docker build does not work correctly. 
Docker image for centos 7 requires `systemd-devel` library.


