### PR TITLE
Build system tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,12 @@ DEFINES=--define '_topdir $(TOP_DIR)' --define '_tmppath $(TOP_DIR)/tmp' --defin
 
 rpms:	clean erlang
 
-prepare:
+build-deps:
+	yum install -y autoconf clang m4 openssl-devel ncurses-devel rpm-build rpmdevtools rpmlint tar wget zlib-devel systemd-devel make
+
+prepare: build-deps
 	mkdir -p BUILD SOURCES SPECS SRPMS RPMS tmp dist
-	wget -O $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) $(ERLANG_DISTPOINT)#
+	wget --no-clobber -O $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) $(ERLANG_DISTPOINT)
 	tar -zxf $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) -C dist
 	cp $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) SOURCES
 	rm $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,11 @@ build-deps:
 
 prepare: build-deps
 	mkdir -p BUILD SOURCES SPECS SRPMS RPMS tmp dist
+ifneq ("$(wildcard $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE))", "")
+	# file exists
+else
 	wget --no-clobber -O $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) $(ERLANG_DISTPOINT)
+endif
 	tar -zxf $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) -C dist
 	cp $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) SOURCES
 	rm $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE)

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -11,6 +11,8 @@ RUN yum install -y \
   openssl-devel \
   ncurses-devel \
   rpm-build \
+  rpmdevtools \
+  rpmlint \
   tar \
   wget \
   zlib-devel \

--- a/erlang.spec
+++ b/erlang.spec
@@ -16,6 +16,9 @@
 %global package_ver  25.3
 %global package_ver_release 1
 
+# See https://fedoraproject.org/wiki/Changes/Broken_RPATH_will_fail_rpmbuild
+%global __brp_check_rpaths %{nil}
+
 %define OSL_File_Name                   Erlang_ASL2_LICENSE.txt
 
 Name:		erlang

--- a/erlang.spec
+++ b/erlang.spec
@@ -51,7 +51,6 @@ BuildRequires:  clang
 %if ! (0%{?rhel} && 0%{?rhel} <= 6)
 BuildRequires:  systemd-devel
 %endif
-Obsoletes: erlang-docbuilder
 
 %description
 This is a minimal packaging of Erlang produced by VMware, Inc. to support
@@ -69,9 +68,9 @@ syntax_tools and xmerl.
 %prep
 %setup -q -n otp-OTP-%{upstream_ver}
 
-%patch1 -p1 -b .Do_not_format_man_pages_and_do_not_install_miscellan
-%patch2 -p1 -b .Do_not_install_C_sources
-%patch3 -p1 -F2 -b .Do_not_install_erlang_sources
+%patch 1 -p1 -b .Do_not_format_man_pages_and_do_not_install_miscellan
+%patch 2 -p1 -b .Do_not_install_C_sources
+%patch 3 -p1 -F2 -b .Do_not_install_erlang_sources
 
 # Fix 664 file mode
 chmod 644 lib/kernel/examples/uds_dist/c_src/Makefile


### PR DESCRIPTION
This makes the package build successfully and without warnings on ARM64 Fedora 38 (preview).

References #116, #115, #108.