### PR TITLE
Erlang 24.3.x: sync Docker-based build system with that of main (Erlang 25.3.x)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ tmp
 dist
 docker/*build-dir*
 docker/docker-*
-docker/all_rpms/*
 *~
 .sw?
 .*.sw?

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,12 @@ DEFINES=--define '_topdir $(TOP_DIR)' --define '_tmppath $(TOP_DIR)/tmp' --defin
 
 rpms:	clean erlang
 
-prepare:
+build-deps:
+	yum install -y autoconf clang m4 openssl-devel ncurses-devel rpm-build rpmdevtools rpmlint tar wget zlib-devel systemd-devel make
+
+prepare: build-deps
 	mkdir -p BUILD SOURCES SPECS SRPMS RPMS tmp dist
-	wget -O $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) $(ERLANG_DISTPOINT)#
+	wget --no-clobber -O $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) $(ERLANG_DISTPOINT)
 	tar -zxf $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) -C dist
 	cp $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) SOURCES
 	rm $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,11 @@ build-deps:
 
 prepare: build-deps
 	mkdir -p BUILD SOURCES SPECS SRPMS RPMS tmp dist
+ifneq ("$(wildcard $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE))", "")
+	# file exists
+else
 	wget --no-clobber -O $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) $(ERLANG_DISTPOINT)
+endif
 	tar -zxf $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) -C dist
 	cp $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) SOURCES
 	rm $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE)

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,14 @@ DEFINES=--define '_topdir $(TOP_DIR)' --define '_tmppath $(TOP_DIR)/tmp' --defin
 rpms:	clean erlang
 
 build-deps:
-	yum install -y autoconf clang m4 openssl-devel ncurses-devel rpm-build rpmdevtools rpmlint tar wget zlib-devel systemd-devel make
+	dnf update -y
+	dnf install -y autoconf clang m4 openssl-devel ncurses-devel rpm-build rpmdevtools rpmlint tar wget zlib-devel systemd-devel make
 
 prepare: build-deps
 	mkdir -p BUILD SOURCES SPECS SRPMS RPMS tmp dist
-ifneq ("$(wildcard $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE))", "")
-	# file exists
+ifneq ("$(wildcard /tmp/$(OTP_SRC_TGZ_FILE))","")
+	# for faster turnaround time during development
+	cp /tmp/$(OTP_SRC_TGZ_FILE) $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE)
 else
 	wget --no-clobber -O $(TARBALL_DIR)/$(OTP_SRC_TGZ_FILE) $(ERLANG_DISTPOINT)
 endif
@@ -44,12 +46,12 @@ endif
 	cp *.patch SOURCES
 	cp erlang.spec SPECS
 	cp Erlang_ASL2_LICENSE.txt SOURCES
-	yum update -y
-	yum install -y util-linux
+	dnf update -y
+	dnf install -y util-linux
 	if test -f /etc/os-release; then \
 		. /etc/os-release; \
 		if test "$$ID" = 'centos' && test "$$VERSION_ID" -ge 7; then \
-			yum install -y rpm-sign; \
+			dnf install -y rpm-sign; \
 		fi; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ plugins.
 
 ## Supported RPM-based Distributions
 
-These packages target **modern RHEL and CentOS versions** (RHEL/CentOS Stream 8+) as well as recent Fedora releases:
+Binary builds of this package target **modern RHEL and CentOS versions** (RHEL/CentOS Stream 8+) as well as recent Fedora releases:
 
  * RHEL 8.4 or later
  * CentOS Stream 8

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ For CentOS Stream 9, replace the `8` in the examples above with a `9`.
 
 ### Without Docker
 
-You must be running an RPM-based distro (CentOS 8, 7 or equivalent RHEL is highly recommended) for this to work.
+You must be running an RPM-based distro (CentOS Stream 9, modern Fedora or equivalent RHEL is highly recommended) for this to work.
 
 ``` shell
 # add sudo if required by the local Docker installation

--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
 # Zero-dependency Erlang RPM for RabbitMQ
 
-This is a (virtually) zero dependency 64-bit Erlang RPM package that provides **just enough to run RabbitMQ**.
-It may be easier to install than other Erlang RPMs in most environments.
+This is a (virtually) zero dependency Erlang RPM package that provides **just enough to run RabbitMQ**.
 It may or may not be suitable for running other Erlang-based software or 3rd party RabbitMQ
 plugins.
 
+x86-64 binaries are provided with every release, while aarch64 (ARM64)
+binaries will be limited to new major and minor release, and patches when resources allow.
+
+Binary packages can be produced on any host that can run Docker, including
+aarch64 hosts. See the **Building from Source** section below.
+
 ## Supported RPM-based Distributions
 
-Binary builds of this package target **modern RHEL and CentOS versions** (RHEL/CentOS Stream 8+) as well as recent Fedora releases:
+[Binary builds](https://github.com/rabbitmq/erlang-rpm/releases) of this package target **modern RPM-based distributions**:
 
  * RHEL 8.4 or later
  * CentOS Stream 8
  * CentOS Stream 9
  * Rocky Linux 8.5 or later
  * Fedora 34 or later
- * Amazon Linux 2023 (x86-64)
+ * Amazon Linux 2023
+ * Oracle Linux 9
+ * Alma Linux 9
 
-## What about CentOS 7 and derivatives?
+## CentOS 7 and derivatives
 
 Older releases (up to [Erlang 23.3.4.11](https://github.com/rabbitmq/erlang-rpm/releases/tag/v23.3.4.11))
 include builds for CentOS 7 and CentOS 7-based distributions (namely Amazon Linux 2), and OpenSSL 1.0.
@@ -25,7 +32,7 @@ This package has an **implicit OpenSSL/libcrypto dependency** (see below). Start
 the minimum required version is **an equivalent of OpenSSL is 1.1**, only provided by Fedora,
 Rocky Linux, CentOS Stream 8 and CentOS Stream 9.
 
-## What about Debian-based distributions?
+## Packages for Debian-based Distributions
 
 Team RabbitMQ also packages [recent Erlang/OTP releases for Debian](https://www.rabbitmq.com/install-debian.html#erlang-repositories)
 and [a modern Erlang PPA for Ubuntu](https://rabbitmq.com/install-debian.html#apt-launchpad-erlang).
@@ -33,28 +40,31 @@ and [a modern Erlang PPA for Ubuntu](https://rabbitmq.com/install-debian.html#ap
 
 ## Provided Erlang/OTP Versions
 
-The package targets Erlang/OTP `24.x` and `23.x`. Only 64-bit (x86-64) packages are provided.
+The package targets Erlang/OTP `25.x` and `24.x`. Both x86-64 and aarch64 versions can be
+build in containers.
+
+**Important**: Erlang 26 introduce a number of breaking changes around networking and TLS.
+Packages of Erlang 26 will be provided when Erlang 26 support ships in a GA RabbitMQ release.
 
 ### RabbitMQ Version Compatibility
 
 See [Supported Erlang Versions](https://www.rabbitmq.com/which-erlang.html) in RabbitMQ documentation
 for an up-to-date compatibility matrix.
 
+#### Erlang 25
+
+Erlang 25 is supported by RabbitMQ [starting with `3.10.0`](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.10.0).
+
+Erlang 25 depends on OpenSSL 1.1, which is **not available on CentOS 7**. Therefore Erlang 25 packages
+are **only produced for modern Fedora, Rocky Linux, CentOS Stream, and Amazon Linux 2023**.
+
+
 #### Erlang 24
 
-Erlang 24 is supported by RabbitMQ [starting with `3.8.16`](https://www.rabbitmq.com/changelog.html)
-[as of May 2021](https://blog.rabbitmq.com/posts/2021/03/erlang-24-support-roadmap/).
+Erlang 24 is supported by RabbitMQ [starting with `3.8.16`](https://www.rabbitmq.com/changelog.html).
 
 Erlang 24 depends on OpenSSL 1.1, which is **not available on CentOS 7**. Therefore Erlang 24 packages
 are **only produced for modern Fedora, Rocky Linux and CentOS Stream**.
-
-#### Erlang 23
-
-Erlang 23 is supported by RabbitMQ [starting with `3.8.4`](https://groups.google.com/forum/#!topic/rabbitmq-users/wlPIWz3UYHQ).
-
-[RabbitMQ Erlang Version Requirements guide](https://www.rabbitmq.com/which-erlang.html) explains what Erlang/OTP
-releases are supported by a given RabbitMQ release. We **highly recommend** following the recommendations
-from that guide and using the most recent release in the supported series.
 
 
 ## Implicit OpenSSL/libcrypto Dependency
@@ -62,22 +72,14 @@ from that guide and using the most recent release in the supported series.
 This package intentionally **does not include OpenSSL**/libcrypto. It must be provisioned separately.
 Recent Erlang versions require a modern OpenSSL version, currently this means `1.1.x` or later.
 
-## Supported RHEL, CentOS and Fedora Versions
-
-Please note the **implicit OpenSSL/libcrypto dependency** section above.
-
- * For Erlang 24: supports RHEL or CentOS Stream 9 or CentOS Stream 8, modern Fedora, Rocky Linux. **Requires OpenSSL 1.1**
- * for Erlang 23: supports RHEL or CentOS Stream 9 or CentOS Stream 8, modern Fedora. Requires OpenSSL 1.0.x or 1.1.
-
-
 ## Release Artifacts
 
 For direct RPM package downloads, see [GitHub releases](https://github.com/rabbitmq/erlang-rpm/releases).
 
-There are two Yum repositories that distributed this package:
+There are two dnf repositories that distributed this package:
 
+ * [rabbitmq/erlang on PackageCloud](https://packagecloud.io/rabbitmq/erlang/)
  * [rabbitmq/rabbitmq-erlang on Cloudsmith.io](https://cloudsmith.io/~rabbitmq/repos/rabbitmq-erlang/setup/#repository-setup-yum)
- * [rabbitmq/erlang on Package Cloud](https://packagecloud.io/rabbitmq/erlang/)
 
 See the repository setup instructions below.
 
@@ -90,7 +92,7 @@ The package is signed using the standard [RabbitMQ signing key](https://www.rabb
 rpm --import https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
 ```
 
-To use the Cloudsmith Yum repository, a [separate Cloudsmith repository key](https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key) must be imported:
+To use the Cloudsmith dnf repository, a [separate Cloudsmith repository key](https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key) must be imported:
 
 ``` shell
 ## primary RabbitMQ signing key
@@ -99,7 +101,7 @@ rpm --import https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabb
 rpm --import 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key'
 ```
 
-To use the PackageCloud Yum repository, a [separate PackageCloud repository key](https://packagecloud.io/rabbitmq/erlang/gpgkey) must be imported:
+To use the PackageCloud dnf repository, a [separate PackageCloud repository key](https://packagecloud.io/rabbitmq/erlang/gpgkey) must be imported:
 
 ``` shell
 ## primary RabbitMQ signing key
@@ -108,15 +110,183 @@ rpm --import https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabb
 rpm --import https://packagecloud.io/rabbitmq/erlang/gpgkey
 ```
 
-### Latest Erlang Version from Cloudsmith
+## Direct Downloads from GitHub
 
-Cloudsmith provides shell scripts for quick Yum repository setup.
+This package is [distributed as a single RPM](https://github.com/rabbitmq/erlang-rpm/releases), which makes it convenient to
+download and install using `dnf install -y /path/to/erlang.rpm`.
+
+#### Erlang 25 on CentOS Stream 9, Amazon Linux 2023, modern Fedora (x86-64 and aarch)
+
+Erlang 25 x86-64 and aarch64 releases can be provisioned on RHEL 9, CentOS Stream 9, Amazon Linux 2023,
+and modern Fedora using a [direct download](https://github.com/rabbitmq/erlang-rpm/releases):
+
+``` shell
+# This is just an example that uses an aarch64 package for Amazon Linux 2023
+cd /tmp/
+curl -sfL -O https://github.com/rabbitmq/erlang-rpm/releases/download/v25.3/erlang-25.3-1.amzn2023.aarch64.rpm
+sudo dnf install -y ./erlang-25.3-1.amzn2023.aarch64.rpm
+```
+
+### Latest Erlang Version from PackageCloud
+
+This package is distributed via a [dnf repository on PackageCloud](https://packagecloud.io/rabbitmq/erlang).
+
+PackageCloud provides a shell script for quick repository setup:
+
+``` shell
+# inspect the script running it in a sudo shell!
+curl -s https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
+```
+
+#### Erlang 25 on RHEL 9, CentOS Stream 9, modern Fedora, Rocky Linux
+
+To use the most recent version on CentOS Stream 9, modern Fedora, Rocky Linux:
+
+``` ini
+# In /etc/yum.repos.d/rabbitmq_erlang.repo
+[rabbitmq_erlang]
+name=rabbitmq_erlang
+baseurl=https://packagecloud.io/rabbitmq/erlang/el/9/$basearch
+repo_gpgcheck=1
+gpgcheck=1
+enabled=1
+# PackageCloud's repository key and RabbitMQ package signing key
+gpgkey=https://packagecloud.io/rabbitmq/erlang/gpgkey
+       https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+
+[rabbitmq_erlang-source]
+name=rabbitmq_erlang-source
+baseurl=https://packagecloud.io/rabbitmq/erlang/el/9/SRPMS
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+# PackageCloud's repository key and RabbitMQ package signing key
+gpgkey=https://packagecloud.io/rabbitmq/erlang/gpgkey
+       https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+```
+
+To install the package:
+
+``` shell
+dnf install erlang
+```
+
+#### Erlang 25 on RHEL 8, CentOS 8, modern Fedora, Rocky Linux
+
+To use the most recent version on CentOS 8:
+
+``` ini
+# In /etc/yum.repos.d/rabbitmq_erlang.repo
+[rabbitmq_erlang]
+name=rabbitmq_erlang
+baseurl=https://packagecloud.io/rabbitmq/erlang/el/8/$basearch
+repo_gpgcheck=1
+gpgcheck=1
+enabled=1
+# PackageCloud's repository key and RabbitMQ package signing key
+gpgkey=https://packagecloud.io/rabbitmq/erlang/gpgkey
+       https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+
+[rabbitmq_erlang-source]
+name=rabbitmq_erlang-source
+baseurl=https://packagecloud.io/rabbitmq/erlang/el/8/SRPMS
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+# PackageCloud's repository key and RabbitMQ package signing key
+gpgkey=https://packagecloud.io/rabbitmq/erlang/gpgkey
+       https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+```
+
+To install the package:
+
+``` shell
+dnf install erlang
+```
+
+## Latest Erlang Version from Cloudsmith
+
+This package is distributed via a [dnf repository on Cloudsmith](https://cloudsmith.io/~rabbitmq/repos/rabbitmq-erlang/packages/).
+
+Cloudsmith provides shell scripts for quick dnf repository setup.
 See the [Cloudsmith repository installation](https://cloudsmith.io/~rabbitmq/repos/rabbitmq-erlang/setup/#repository-setup-yum) page
 for details.
 
-#### Erlang 24 on RHEL 8, CentOS 8, modern Fedora, Rocky Linux
+### Erlang 25 on RHEL 9, CentOS Stream 9, modern Fedora, Rocky Linux (x86-64)
 
-To use the most recent Erlang version on CentOS 8:
+Erlang 25 x86-64 releases can be provisioned on RHEL 9, CentOS Stream 9, Rocky Linux, and modern Fedora
+using a dnf (yum) repository on Cloudsmith:
+
+``` ini
+# In /etc/yum.repos.d/rabbitmq_erlang.repo
+[rabbitmq-rabbitmq-erlang]
+name=rabbitmq-rabbitmq-erlang
+baseurl=https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/rpm/el/9/$basearch
+repo_gpgcheck=1
+enabled=1
+gpgkey=https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key
+gpgcheck=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+pkg_gpgcheck=1
+autorefresh=1
+type=rpm-md
+
+[rabbitmq-rabbitmq-erlang-noarch]
+name=rabbitmq-rabbitmq-erlang-noarch
+baseurl=https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/rpm/el/9/noarch
+repo_gpgcheck=1
+enabled=1
+gpgkey=https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key
+       https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+gpgcheck=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+pkg_gpgcheck=1
+autorefresh=1
+type=rpm-md
+
+[rabbitmq-rabbitmq-erlang-source]
+name=rabbitmq-rabbitmq-erlang-source
+baseurl=https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/rpm/el/9/SRPMS
+repo_gpgcheck=1
+enabled=1
+gpgkey=https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key
+       https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+gpgcheck=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+pkg_gpgcheck=1
+autorefresh=1
+type=rpm-md
+```
+
+To install the package:
+
+``` shell
+dnf update -y
+dnf install -y erlang
+```
+
+### Erlang 25 on RHEL 8, CentOS Stream 8, modern Fedora, Rocky Linux (x86-64)
+
+Erlang 25 x86-64 releases can be provisioned on RHEL 8, CentOS Stream 8, Rocky Linux, and modern Fedora
+using a dnf (yum) repository on Cloudsmith:
 
 ``` ini
 # In /etc/yum.repos.d/rabbitmq_erlang.repo
@@ -168,55 +338,9 @@ type=rpm-md
 To install the package:
 
 ``` shell
-yum update -y
-yum install -y erlang
+dnf update -y
+dnf install -y erlang
 ```
-
-
-### Latest Erlang Version from PackageCloud
-
-#### Erlang 24 on RHEL 8, CentOS 8, modern Fedora, Rocky Linux
-
-To use the most recent version on CentOS 8:
-
-``` ini
-# In /etc/yum.repos.d/rabbitmq_erlang.repo
-[rabbitmq_erlang]
-name=rabbitmq_erlang
-baseurl=https://packagecloud.io/rabbitmq/erlang/el/8/$basearch
-repo_gpgcheck=1
-gpgcheck=1
-enabled=1
-# PackageCloud's repository key and RabbitMQ package signing key
-gpgkey=https://packagecloud.io/rabbitmq/erlang/gpgkey
-       https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-metadata_expire=300
-
-[rabbitmq_erlang-source]
-name=rabbitmq_erlang-source
-baseurl=https://packagecloud.io/rabbitmq/erlang/el/8/SRPMS
-repo_gpgcheck=1
-gpgcheck=0
-enabled=1
-# PackageCloud's repository key and RabbitMQ package signing key
-gpgkey=https://packagecloud.io/rabbitmq/erlang/gpgkey
-       https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-metadata_expire=300
-```
-
-To install the package:
-
-``` shell
-yum install erlang
-```
-
-Note that Erlang 24 packages **implicitly depend on OpenSSL 1.1** which is no available
-on RHEL 7 or CentOS 7. Therefore Erlang 24 packages will fail to install
-on those distributions.
 
 
 ## Available Erlang Applications
@@ -252,44 +376,62 @@ Only the following OTP applications are provided:
 
 ### With Docker
 
+This repository provides scripts that can build an image with the `rpmbuild` toolchain
+and build the package in it. They can be found under the `./docker` directory.
+
 ```sh
 cd docker
 
 #
 # Use build-image-and-rpm.sh to execute all scripts:
-# build a Centos 8 image and build the RPM using it
+# build an image and build the RPM in it
 #
-./build-image-and-rpm.sh 8 --no-cache
+# Supported distribution aliases:
+#  * stream9 for CentOS Stream 9
+#  * stream8 for CentOS Stream 8
+#  * al2023 for Amazon Linux 2023
+#  * f38 for Fedora 38
+#
+./build-image-and-rpm.sh stream9 --no-cache
 
 #
-# To only build a CentOS 8 Docker image with necessary toolchain
+# To only build an image with the necessary toolchain,
+# use ./build-docker-image.sh.
 #
- ./build-docker-image.sh 8 --no-cache
+# Supported distribution aliases:
+#  * stream9 for CentOS Stream 9
+#  * stream8 for CentOS Stream 8
+#  * al2023 for Amazon Linux 2023
+#  * f38 for Fedora 38
+ ./build-docker-image.sh stream9 --no-cache
 
 #
-# To only build the RPM using an already built and available image
+# To only build the RPM using an already built and available image,
+# use ./build-rpm-in-docker.sh
 #
-./build-rpm-in-docker 8
+# Supported distribution aliases:
+#  * stream9 for CentOS Stream 9
+#  * stream8 for CentOS Stream 8
+#  * al2023 for Amazon Linux 2023
+#  * f38 for Fedora 38
+#
+./build-rpm-in-docker.sh stream9
 ```
 
-then find the result under `docker/build-dir-{CentOSVersion}/RPMS/x86_64/`,
-e.g. `build-dir-8/RPMS/x86_64/`.
-
-For CentOS Stream 9, replace the `8` in the examples above with a `9`.
-
+Built packages can be found under `docker/pkg-build-dir/RPMS/{architecture}/`.
 
 ### Without Docker
 
-You must be running an RPM-based distro (CentOS Stream 9, modern Fedora or equivalent RHEL is highly recommended) for this to work.
+On an RPM-based distro (CentOS Stream 9, modern Fedora or Amazon Linux 2023), the package can
+be built without containers.
 
 ``` shell
-# add sudo if required by the local Docker installation
+# add sudo if necessary
 make
 ```
 
-and see `RPMS/x86_64/`. Note that all artifacts created this way may be owned by root
+and see `RPMS/{architecture}/`. Note that all artifacts created this way may be owned by root
 due to the use of `sudo`.
-
 
 ### Scope of Patching
 
@@ -300,12 +442,12 @@ No source code is patched.
 ## Older Versions
 
 The directory `versions` contains the patch files used for the older versions. Git repository
-history can be useful as well.
+history and release archive can be useful as well.
 
 
 ## Copyright and License
 
-Copyright VMware, Inc and its affiliates, 2011-2021. All Rights Reserved.
+Copyright VMware, Inc and its affiliates, 2011-2023. All Rights Reserved.
 
 Released under the [Apache Software License 2.0](./Erlang_ASL2_LICENSE.txt),
 same as Erlang/OTP starting with 18.0.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These packages target **modern RHEL and CentOS versions** (RHEL/CentOS Stream 8+
  * CentOS Stream 9
  * Rocky Linux 8.5 or later
  * Fedora 34 or later
- * Amazon Linux 2023 (Fedora-based)
+ * Amazon Linux 2023 (x86-64)
 
 ## What about CentOS 7 and derivatives?
 

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,4 @@
+build-dir-*/*
+docker-*/*
+pkg-build-dir/*
+all_rpms/*

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -11,6 +11,8 @@ RUN yum install -y \
   openssl-devel \
   ncurses-devel \
   rpm-build \
+  rpmdevtools \
+  rpmlint \
   tar \
   wget \
   zlib-devel \

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -1,23 +1,11 @@
-FROM quay.io/centos/centos:{centosfrom}
+ARG image
+ARG image_tag
 
-RUN yum -y update && yum clean all
+FROM $image:$image_tag
 
-RUN yum install -y \
-  autoconf \
-  # includes gcc and gcc-c++, the latter
-  # is needed to build Erlang/OTP with a JIT
-  clang \
-  m4 \
-  openssl-devel \
-  ncurses-devel \
-  rpm-build \
-  rpmdevtools \
-  rpmlint \
-  tar \
-  wget \
-  zlib-devel \
-  systemd-devel \
-  make
+RUN dnf -y update && dnf clean all
+
+RUN dnf install -y autoconf clang m4 openssl-devel ncurses-devel rpm-build rpmdevtools rpmlint tar wget zlib-devel systemd-devel make sudo
 
 RUN mkdir /build
-CMD ["sh", "-c", "cd /build/build-dir-{centosfrom} && make"]
+CMD ["sh", "-c", "cd /build/pkg-build-dir && make"]

--- a/docker/build-docker-image.sh
+++ b/docker/build-docker-image.sh
@@ -1,38 +1,46 @@
 #!/usr/bin/env sh
 
-docker_file="Dockerfile"
-docker_template="Dockerfile.template"
-centos_version="$1"
+os_name="$1"
 docker_params=${2:-"--pull"}
-docker_dir="docker-centos-$centos_version"
 
-if [ -z "$centos_version" ]
-then
-	echo "
-Ops: parameters error
-first: version, ex: 9, 8, or 7
-second: docker build parameters such as --no-cache
------------------------------------------
-Ex: ./build-docker-image.sh 9 --no-cache
-Ex: ./build-docker-image.sh 8 --no-cache
-Ex: ./build-docker-image.sh 7 --no-cache
-"
-exit 1
-fi
-
-case $centos_version in
-	9)
-		centos_tag=stream9;;
-	8)
-		centos_tag=stream8;;
-	*)
-		# 8 and 7
-		centos_tag="$centos_version";;
+case $os_name in
+	9|stream9|centos9)
+		image="quay.io/centos/centos"
+		image_tag=stream9;;
+	8|stream8|centos8)
+		image="quay.io/centos/centos"
+		image_tag=stream8;;
+	fedora|f38|fc38|fedora38)
+		image="fedora"
+		image_tag="38";;
+	al|al2023|amazonlinux2023)
+		image="amazonlinux"
+		image_tag="2023";;
+	oracle|oracle9|oraclelinux9)
+		image="oraclelinux"
+		image_tag="9";;
+	rocky|rocky9|rockylinux9)
+		image="rockylinux"
+		image_tag="9";;
+	alma|alma9|almalinux9)
+		image="almalinux"
+		image_tag="9";;
 esac
 
-if [ -e "$docker_file" ]
+docker_dir="docker-$os_name"
+
+if [ -z "$os_name" ]
 then
-	rm -f "$docker_file"
+	echo "
+This script takes two arguments.
+first: distribution, one of stream9, stream8, al2023, fedora, rocky, alma, oracle
+second: docker build parameters such as --no-cache
+-----------------------------------------
+Ex: ./build-docker-image.sh stream9 --no-cache
+Ex: ./build-docker-image.sh stream8 --no-cache
+Ex: ./build-docker-image.sh fedora38 --no-cache
+"
+exit 1
 fi
 
 if [ -e "$docker_dir" ]
@@ -42,17 +50,12 @@ fi
 
 mkdir "$docker_dir"
 
-echo "Will build an image for CentOS $centos_version (tag: $centos_tag) using Docker file at $docker_dir/$docker_file"
+echo "Will build an image for ${image}:${image_tag} using Docker file at $docker_dir/Dockerfile"
 
-if [ -e "$docker_template" ]
-then
-	cp "$docker_template" "$docker_dir"/"$docker_file"
+cp Dockerfile.template "$docker_dir/Dockerfile"
 	case $(uname -s) in
 		Linux)
-			sed --in-place=".bak" "s/{centosfrom}/$centos_tag/g" "$docker_dir"/"$docker_file"
-			sudo docker build "$docker_params" -t="erlang-rpm-build-""$centos_version" "$docker_dir";;
+			sudo docker build --build-arg image="$image" --build-arg image_tag="$image_tag" "$docker_params" -t="erlang-rpm-build-$os_name" "$docker_dir";;
 		*)
-			sed -i ".bak" "s/{centosfrom}/$centos_tag/g" "$docker_dir"/"$docker_file"
-			docker build "$docker_params" -t="erlang-rpm-build-""$centos_version" "$docker_dir";;
+			docker build --build-arg image="$image" --build-arg image_tag="$image_tag" "$docker_params" -t="erlang-rpm-build-$os_name" "$docker_dir";;
 	esac
-fi

--- a/docker/build-image-and-rpm.sh
+++ b/docker/build-image-and-rpm.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env sh
 
 usage() {
-  	echo "parameters error"
-	echo "first: version, e.g. '9' or '8' "
-	echo "second: --no-cache [optional]"
-	echo "es: ./build-image-and-rpm.sh '8' --no-cache"
+	echo "
+This script takes two arguments.
+first: distribution, one of stream9, stream8, al2023, fedora, rocky, alma, oracle
+second: docker build parameters such as --no-cache
+-----------------------------------------
+Ex: ./build-image-and-rpm.sh stream9 --no-cache
+Ex: ./build-image-and-rpm.sh stream8 --no-cache
+Ex: ./build-image-and-rpm.sh fedora38 --no-cache
+"
   exit 1
 }
 

--- a/docker/build-packages.sh
+++ b/docker/build-packages.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env sh
 
-./build-image-and-rpm.sh 8 --no-cache
-./build-image-and-rpm.sh 7 --no-cache
+const all_rpms_dir="all_rpms"
+
+mkdir -p all_rpms_dir
+
+build_and_fetch_rpm_for() {
+  distribution=$1
+  ./build-image-and-rpm.sh "$distribution"
+  cp pkg-build-dir/RPMS/*/erlang-* all_rpms/
+}
+
+# These cover CentOS Stream, Rocky Linux, Alma Linux, Oracle Linux
+# of the same respective version
+build_and_fetch_rpm_for "stream9"
+build_and_fetch_rpm_for "stream8"
+# These distributions cannot use CentOS Stream packages
+build_and_fetch_rpm_for "al2023"
+build_and_fetch_rpm_for "fc38"
+

--- a/docker/build-rpm-in-docker.sh
+++ b/docker/build-rpm-in-docker.sh
@@ -1,31 +1,24 @@
 #!/usr/bin/env bash
 
-centos_version="$1"
-case $centos_version in
-	9)
-		centos_tag=stream9;;
-	*)
-		# 8 and 7
-		centos_tag="$centos_version";;
-esac
+os_name="$1"
 
 # this has to match what Dockerfile uses
-build_dir="build-dir-$centos_tag"
-packages=("Makefile" "erlang.spec" "Erlang_ASL2_LICENSE.txt")
+build_dir="pkg-build-dir"
+pkg_files=("Makefile" "erlang.spec" "Erlang_ASL2_LICENSE.txt")
 
-if [ -z "$centos_version" ]
+if [ -z "$os_name" ]
 then
 	echo "
 Ops: parameters error
-first: version, ex: 9 or 8
+first: version or distribution name, ex: stream9, stream8, f38
 -----------------------------------------
-Ex: ./build-rpm-in-docker.sh 9
-Ex: ./build-rpm-in-docker.sh 8
+Ex: ./build-rpm-in-docker.sh stream9
+Ex: ./build-rpm-in-docker.sh stream8
 "
 	exit 1
 fi
 
-echo "Recreating build dir $build_dir"
+echo "Re-creating build dir $build_dir"
 
 if [ -e "$build_dir" ]
 then
@@ -38,19 +31,14 @@ echo "Copying patches to build dir $build_dir"
 cp ../*.patch "$build_dir"
 
 echo "Copying other files to build dir $build_dir"
-for file in "${packages[@]}"
+for file in "${pkg_files[@]}"
 do
 	cp ../"$file" "$build_dir"
 done
 
-if [ -e ../dist ]
-then
-	cp -r ../dist "$build_dir"/dist
-fi
-
 case $(uname -s) in
 	Linux)
-		sudo docker run -i -t -v "$PWD"/"$build_dir":/build/"$build_dir" erlang-rpm-build-"$centos_version";;
+		sudo docker run -i -t -v "$PWD"/"$build_dir":/build/"$build_dir" "erlang-rpm-build-$os_name";;
 	*)
-		docker run -i -t -v "$PWD"/"$build_dir":/build/"$build_dir" erlang-rpm-build-"$centos_version";;
+		docker run -i -t -v "$PWD"/"$build_dir":/build/"$build_dir" "erlang-rpm-build-$os_name";;
 esac

--- a/erlang.spec
+++ b/erlang.spec
@@ -35,11 +35,11 @@ Vendor:		VMware, Inc.
 
 
 #   Do not format man-pages and do not install miscellaneous
-Patch1: otp-0001-Do-not-format-man-pages-and-do-not-install-miscellan.patch
+Patch0: otp-0001-Do-not-format-man-pages-and-do-not-install-miscellan.patch
 #   Do not install C sources
-Patch2: otp-0002-Do-not-install-C-sources.patch
+Patch1: otp-0002-Do-not-install-C-sources.patch
 #   Do not install erlang sources
-Patch3: otp-0003-Do-not-install-erlang-sources.patch
+Patch2: otp-0003-Do-not-install-erlang-sources.patch
 
 # BuildRoot not strictly needed since F10, but keep it for spec file robustness
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
@@ -51,9 +51,7 @@ BuildRequires:	m4
 BuildRequires:	autoconf
 # will install gcc and gcc-c++ as dependencies
 BuildRequires:  clang
-%if ! (0%{?rhel} && 0%{?rhel} <= 6)
 BuildRequires:  systemd-devel
-%endif
 
 %description
 This is a minimal packaging of Erlang produced by VMware, Inc. to support
@@ -71,9 +69,8 @@ syntax_tools and xmerl.
 %prep
 %setup -q -n otp-OTP-%{upstream_ver}
 
-%patch 1 -p1 -b .Do_not_format_man_pages_and_do_not_install_miscellan
-%patch 2 -p1 -b .Do_not_install_C_sources
-%patch 3 -p1 -F2 -b .Do_not_install_erlang_sources
+# Automatically apply all listed patches
+%autopatch -v -p 1
 
 # Fix 664 file mode
 chmod 644 lib/kernel/examples/uds_dist/c_src/Makefile
@@ -83,11 +80,7 @@ chmod 644 lib/ssl/examples/src/Makefile
 
 
 %build
-%if ! (0%{?rhel} && 0%{?rhel} <= 6)
 %global conf_flags --enable-shared-zlib --enable-systemd --without-javac --without-odbc
-%else
-%global conf_flags --enable-shared-zlib --without-javac --without-odbc
-%endif
 
 %ifarch sparcv9 sparc64
 CFLAGS="$RPM_OPT_FLAGS -mcpu=ultrasparc -fno-strict-aliasing" %configure %{conf_flags}

--- a/erlang.spec
+++ b/erlang.spec
@@ -16,6 +16,9 @@
 %global package_ver  24.3.4.11
 %global package_ver_release 1
 
+# See https://fedoraproject.org/wiki/Changes/Broken_RPATH_will_fail_rpmbuild
+%global __brp_check_rpaths %{nil}
+
 %define OSL_File_Name                   Erlang_ASL2_LICENSE.txt
 
 Name:		erlang

--- a/erlang.spec
+++ b/erlang.spec
@@ -48,8 +48,9 @@ BuildRequires:	m4
 BuildRequires:	autoconf
 # will install gcc and gcc-c++ as dependencies
 BuildRequires:  clang
-
-Obsoletes: erlang-docbuilder
+%if ! (0%{?rhel} && 0%{?rhel} <= 6)
+BuildRequires:  systemd-devel
+%endif
 
 %description
 This is a minimal packaging of Erlang produced by VMware, Inc. to support
@@ -67,9 +68,9 @@ syntax_tools and xmerl.
 %prep
 %setup -q -n otp-OTP-%{upstream_ver}
 
-%patch1 -p1 -b .Do_not_format_man_pages_and_do_not_install_miscellan
-%patch2 -p1 -b .Do_not_install_C_sources
-%patch3 -p1 -F2 -b .Do_not_install_erlang_sources
+%patch 1 -p1 -b .Do_not_format_man_pages_and_do_not_install_miscellan
+%patch 2 -p1 -b .Do_not_install_C_sources
+%patch 3 -p1 -F2 -b .Do_not_install_erlang_sources
 
 # Fix 664 file mode
 chmod 644 lib/kernel/examples/uds_dist/c_src/Makefile

--- a/otp-0003-Do-not-install-erlang-sources.patch
+++ b/otp-0003-Do-not-install-erlang-sources.patch
@@ -1,6 +1,6 @@
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/asn1/src/Makefile otp-24.0-patched/lib/asn1/src/Makefile
---- otp-24.0/lib/asn1/src/Makefile	2021-05-12 21:31:53.000000000 +0100
-+++ otp-24.0-patched/lib/asn1/src/Makefile	2020-05-13 23:51:34.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/asn1/src/Makefile otp-src-patched/lib/asn1/src/Makefile
+--- otp-src/lib/asn1/src/Makefile	2021-05-12 21:31:53.000000000 +0100
++++ otp-src-patched/lib/asn1/src/Makefile	2020-05-13 23:51:34.000000000 +0100
 @@ -151,7 +151,7 @@
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(APP_TARGET) $(APPUP_TARGET) "$(RELSYSDIR)/ebin"
@@ -10,9 +10,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/asn1/src/Make
  	$(INSTALL_DIR) "$(RELSYSDIR)/examples"
  	$(INSTALL_DATA) $(EXAMPLES) "$(RELSYSDIR)/examples"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/compiler/src/Makefile otp-24.0-patched/lib/compiler/src/Makefile
---- otp-24.0/lib/compiler/src/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-24.0-patched/lib/compiler/src/Makefile	2020-05-13 23:52:23.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/compiler/src/Makefile otp-src-patched/lib/compiler/src/Makefile
+--- otp-src/lib/compiler/src/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-src-patched/lib/compiler/src/Makefile	2020-05-13 23:52:23.000000000 +0100
 @@ -182,8 +182,8 @@
 
  release_spec: opt
@@ -24,9 +24,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/compiler/src/
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(INSTALL_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/crypto/src/Makefile otp-24.0-patched/lib/crypto/src/Makefile
---- otp-24.0/lib/crypto/src/Makefile	2021-05-12 21:31:53.000000000 +0100
-+++ otp-24.0-patched/lib/crypto/src/Makefile	2020-05-13 23:52:42.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/crypto/src/Makefile otp-src-patched/lib/crypto/src/Makefile
+--- otp-src/lib/crypto/src/Makefile	2021-05-12 21:31:53.000000000 +0100
++++ otp-src-patched/lib/crypto/src/Makefile	2020-05-13 23:52:42.000000000 +0100
 @@ -81,8 +81,6 @@
  include $(ERL_TOP)/make/otp_release_targets.mk
 
@@ -36,9 +36,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/crypto/src/Ma
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(APP_TARGET) \
  		$(APPUP_TARGET) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/debugger/src/Makefile otp-24.0-patched/lib/debugger/src/Makefile
---- otp-24.0/lib/debugger/src/Makefile	2021-05-12 21:31:57.000000000 +0100
-+++ otp-24.0-patched/lib/debugger/src/Makefile	2020-05-13 23:53:33.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/debugger/src/Makefile otp-src-patched/lib/debugger/src/Makefile
+--- otp-src/lib/debugger/src/Makefile	2021-05-12 21:31:57.000000000 +0100
++++ otp-src-patched/lib/debugger/src/Makefile	2020-05-13 23:53:33.000000000 +0100
 @@ -117,7 +117,7 @@
 
  release_spec: opt
@@ -48,9 +48,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/debugger/src/
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(TARGET_TOOLBOX_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/edoc/src/Makefile otp-24.0-patched/lib/edoc/src/Makefile
---- otp-24.0/lib/edoc/src/Makefile	2021-05-12 21:31:56.000000000 +0100
-+++ otp-24.0-patched/lib/edoc/src/Makefile	2020-05-13 23:54:07.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/edoc/src/Makefile otp-src-patched/lib/edoc/src/Makefile
+--- otp-src/lib/edoc/src/Makefile	2021-05-12 21:31:56.000000000 +0100
++++ otp-src-patched/lib/edoc/src/Makefile	2020-05-13 23:54:07.000000000 +0100
 @@ -87,7 +87,6 @@
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(OBJECTS) "$(RELSYSDIR)/ebin"
@@ -60,9 +60,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/edoc/src/Make
 
  release_docs_spec:
 -
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/erl_docgen/src/Makefile otp-24.0-patched/lib/erl_docgen/src/Makefile
---- otp-24.0/lib/erl_docgen/src/Makefile	2021-05-12 21:31:55.000000000 +0100
-+++ otp-24.0-patched/lib/erl_docgen/src/Makefile	2020-05-13 23:54:26.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/erl_docgen/src/Makefile otp-src-patched/lib/erl_docgen/src/Makefile
+--- otp-src/lib/erl_docgen/src/Makefile	2021-05-12 21:31:55.000000000 +0100
++++ otp-src-patched/lib/erl_docgen/src/Makefile	2020-05-13 23:54:26.000000000 +0100
 @@ -91,8 +91,6 @@
  include $(ERL_TOP)/make/otp_release_targets.mk
 
@@ -72,9 +72,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/erl_docgen/sr
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/http_client/Makefile otp-24.0-patched/lib/inets/src/http_client/Makefile
---- otp-24.0/lib/inets/src/http_client/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-24.0-patched/lib/inets/src/http_client/Makefile	2019-05-28 00:02:47.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/http_client/Makefile otp-src-patched/lib/inets/src/http_client/Makefile
+--- otp-src/lib/inets/src/http_client/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-src-patched/lib/inets/src/http_client/Makefile	2019-05-28 00:02:47.000000000 +0100
 @@ -92,7 +92,7 @@
  release_spec: opt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/src"
@@ -84,9 +84,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/htt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/http_lib/Makefile otp-24.0-patched/lib/inets/src/http_lib/Makefile
---- otp-24.0/lib/inets/src/http_lib/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-24.0-patched/lib/inets/src/http_lib/Makefile	2019-05-28 00:03:10.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/http_lib/Makefile otp-src-patched/lib/inets/src/http_lib/Makefile
+--- otp-src/lib/inets/src/http_lib/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-src-patched/lib/inets/src/http_lib/Makefile	2019-05-28 00:03:10.000000000 +0100
 @@ -90,7 +90,7 @@
  release_spec: opt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/src"
@@ -96,9 +96,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/htt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/http_server/Makefile otp-24.0-patched/lib/inets/src/http_server/Makefile
---- otp-24.0/lib/inets/src/http_server/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-24.0-patched/lib/inets/src/http_server/Makefile	2019-05-28 00:03:32.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/http_server/Makefile otp-src-patched/lib/inets/src/http_server/Makefile
+--- otp-src/lib/inets/src/http_server/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-src-patched/lib/inets/src/http_server/Makefile	2019-05-28 00:03:32.000000000 +0100
 @@ -134,7 +134,7 @@
  release_spec: opt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/src"
@@ -108,9 +108,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/htt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(BEHAVIOUR_TARGET_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/inets_app/Makefile otp-24.0-patched/lib/inets/src/inets_app/Makefile
---- otp-24.0/lib/inets/src/inets_app/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-24.0-patched/lib/inets/src/inets_app/Makefile	2019-05-28 00:03:53.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/inets_app/Makefile otp-src-patched/lib/inets/src/inets_app/Makefile
+--- otp-src/lib/inets/src/inets_app/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-src-patched/lib/inets/src/inets_app/Makefile	2019-05-28 00:03:53.000000000 +0100
 @@ -114,7 +114,7 @@
  release_spec: opt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/src"
@@ -120,9 +120,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/ine
  	$(INSTALL_DIR)  "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(EXTERNAL_HRL_FILES) "$(RELSYSDIR)/include"
  	$(INSTALL_DIR)  "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/kernel/src/Makefile otp-24.0-patched/lib/kernel/src/Makefile
---- otp-24.0/lib/kernel/src/Makefile	2021-05-12 21:31:59.000000000 +0100
-+++ otp-24.0-patched/lib/kernel/src/Makefile	2019-05-28 00:04:12.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/kernel/src/Makefile otp-src-patched/lib/kernel/src/Makefile
+--- otp-src/lib/kernel/src/Makefile	2021-05-12 21:31:59.000000000 +0100
++++ otp-src-patched/lib/kernel/src/Makefile	2019-05-28 00:04:12.000000000 +0100
 @@ -228,7 +228,6 @@
 
  release_spec: opt
@@ -131,9 +131,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/kernel/src/Ma
  	$(INSTALL_DATA) $(INTERNAL_HRL_FILES) "$(RELSYSDIR)/src"
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)/include"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/mnesia/src/Makefile otp-24.0-patched/lib/mnesia/src/Makefile
---- otp-24.0/lib/mnesia/src/Makefile	2021-05-12 21:31:59.000000000 +0100
-+++ otp-24.0-patched/lib/mnesia/src/Makefile	2019-05-28 00:04:48.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/mnesia/src/Makefile otp-src-patched/lib/mnesia/src/Makefile
+--- otp-src/lib/mnesia/src/Makefile	2021-05-12 21:31:59.000000000 +0100
++++ otp-src-patched/lib/mnesia/src/Makefile	2019-05-28 00:04:48.000000000 +0100
 @@ -135,7 +135,7 @@
 
  release_spec: opt
@@ -143,9 +143,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/mnesia/src/Ma
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/os_mon/src/Makefile otp-24.0-patched/lib/os_mon/src/Makefile
---- otp-24.0/lib/os_mon/src/Makefile	2021-05-12 21:31:55.000000000 +0100
-+++ otp-24.0-patched/lib/os_mon/src/Makefile	2019-05-28 00:05:12.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/os_mon/src/Makefile otp-src-patched/lib/os_mon/src/Makefile
+--- otp-src/lib/os_mon/src/Makefile	2021-05-12 21:31:55.000000000 +0100
++++ otp-src-patched/lib/os_mon/src/Makefile	2019-05-28 00:05:12.000000000 +0100
 @@ -95,7 +95,6 @@
 
  release_spec: opt
@@ -154,9 +154,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/os_mon/src/Ma
  	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)/src"
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/parsetools/src/Makefile otp-24.0-patched/lib/parsetools/src/Makefile
---- otp-24.0/lib/parsetools/src/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-24.0-patched/lib/parsetools/src/Makefile	2019-05-28 00:05:52.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/parsetools/src/Makefile otp-src-patched/lib/parsetools/src/Makefile
+--- otp-src/lib/parsetools/src/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-src-patched/lib/parsetools/src/Makefile	2019-05-28 00:05:52.000000000 +0100
 @@ -91,8 +91,6 @@
  include $(ERL_TOP)/make/otp_release_targets.mk
 
@@ -166,9 +166,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/parsetools/sr
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/public_key/src/Makefile otp-24.0-patched/lib/public_key/src/Makefile
---- otp-24.0/lib/public_key/src/Makefile	2021-05-12 21:31:57.000000000 +0100
-+++ otp-24.0-patched/lib/public_key/src/Makefile	2019-05-28 00:06:31.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/public_key/src/Makefile otp-src-patched/lib/public_key/src/Makefile
+--- otp-src/lib/public_key/src/Makefile	2021-05-12 21:31:57.000000000 +0100
++++ otp-src-patched/lib/public_key/src/Makefile	2019-05-28 00:06:31.000000000 +0100
 @@ -110,8 +108,6 @@
  include $(ERL_TOP)/make/otp_release_targets.mk
 
@@ -178,9 +178,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/public_key/sr
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)/include"
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/reltool/src/Makefile otp-24.0-patched/lib/reltool/src/Makefile
---- otp-24.0/lib/reltool/src/Makefile	2021-05-12 21:31:57.000000000 +0100
-+++ otp-24.0-patched/lib/reltool/src/Makefile	2019-05-28 00:07:05.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/reltool/src/Makefile otp-src-patched/lib/reltool/src/Makefile
+--- otp-src/lib/reltool/src/Makefile	2021-05-12 21:31:57.000000000 +0100
++++ otp-src-patched/lib/reltool/src/Makefile	2019-05-28 00:07:05.000000000 +0100
 @@ -100,7 +100,7 @@
 
  release_spec: opt
@@ -190,9 +190,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/reltool/src/M
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(APP_TARGET) $(APPUP_TARGET) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/runtime_tools/src/Makefile otp-24.0-patched/lib/runtime_tools/src/Makefile
---- otp-24.0/lib/runtime_tools/src/Makefile	2021-05-12 21:31:55.000000000 +0100
-+++ otp-24.0-patched/lib/runtime_tools/src/Makefile	2019-05-28 00:07:27.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/runtime_tools/src/Makefile otp-src-patched/lib/runtime_tools/src/Makefile
+--- otp-src/lib/runtime_tools/src/Makefile	2021-05-12 21:31:55.000000000 +0100
++++ otp-src-patched/lib/runtime_tools/src/Makefile	2019-05-28 00:07:27.000000000 +0100
 @@ -99,8 +99,6 @@
  include $(ERL_TOP)/make/otp_release_targets.mk
 
@@ -202,9 +202,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/runtime_tools
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)/include"
  	$(INSTALL_DIR) "$(RELSYSDIR)/examples"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/sasl/src/Makefile otp-24.0-patched/lib/sasl/src/Makefile
---- otp-24.0/lib/sasl/src/Makefile	2021-05-12 21:31:55.000000000 +0100
-+++ otp-24.0-patched/lib/sasl/src/Makefile	2019-05-28 00:07:59.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/sasl/src/Makefile otp-src-patched/lib/sasl/src/Makefile
+--- otp-src/lib/sasl/src/Makefile	2021-05-12 21:31:55.000000000 +0100
++++ otp-src-patched/lib/sasl/src/Makefile	2019-05-28 00:07:59.000000000 +0100
 @@ -94,7 +94,6 @@
 
  release_spec: opt
@@ -213,10 +213,10 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/sasl/src/Make
  	$(INSTALL_DATA) $(INTERNAL_HRL_FILES) "$(RELSYSDIR)/src"
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/agent/Makefile otp-24.0-patched/lib/snmp/src/agent/Makefile
---- otp-24.0/lib/snmp/src/agent/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-24.0-patched/lib/snmp/src/agent/Makefile	2019-05-28 00:08:21.000000000 +0100
-@@ -151,7 +151,7 @@
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/agent/Makefile.in otp-src-patched/lib/snmp/src/agent/Makefile.in
+--- otp-src/lib/snmp/src/agent/Makefile.in	2021-05-12 21:31:54.000000000 +0100
++++ otp-src-patched/lib/snmp/src/agent/Makefile.in	2019-05-28 00:08:21.000000000 +0100
+@@ -161,7 +161,7 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/src"
  	$(INSTALL_DIR) "$(RELSYSDIR)/src/agent"
@@ -225,9 +225,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/agen
 	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
 	$(INSTALL_DATA) $(BEHAVIOUR_TARGET_FILES) $(TARGET_FILES) $(APP_TARGET) $(APPUP_TARGET) \
 		"$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/app/Makefile otp-24.0-patched/lib/snmp/src/app/Makefile
---- otp-24.0/lib/snmp/src/app/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-24.0-patched/lib/snmp/src/app/Makefile	2019-05-28 00:08:48.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/app/Makefile otp-src-patched/lib/snmp/src/app/Makefile
+--- otp-src/lib/snmp/src/app/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-src-patched/lib/snmp/src/app/Makefile	2019-05-28 00:08:48.000000000 +0100
 @@ -144,7 +144,7 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/src"
@@ -237,9 +237,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/app/
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(APP_TARGET) $(APPUP_TARGET) \
  		"$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/compile/Makefile otp-24.0-patched/lib/snmp/src/compile/Makefile
---- otp-24.0/lib/snmp/src/compile/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-24.0-patched/lib/snmp/src/compile/Makefile	2019-05-28 00:09:19.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/compile/Makefile otp-src-patched/lib/snmp/src/compile/Makefile
+--- otp-src/lib/snmp/src/compile/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-src-patched/lib/snmp/src/compile/Makefile	2019-05-28 00:09:19.000000000 +0100
 @@ -137,7 +137,7 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/src"
@@ -249,9 +249,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/comp
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(EBIN_FILES) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DIR) "$(RELSYSDIR)/bin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/manager/Makefile otp-24.0-patched/lib/snmp/src/manager/Makefile
---- otp-24.0/lib/snmp/src/manager/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-24.0-patched/lib/snmp/src/manager/Makefile	2019-05-28 00:09:43.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/manager/Makefile otp-src-patched/lib/snmp/src/manager/Makefile
+--- otp-src/lib/snmp/src/manager/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-src-patched/lib/snmp/src/manager/Makefile	2019-05-28 00:09:43.000000000 +0100
 @@ -135,7 +135,7 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/src"
@@ -261,9 +261,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/mana
 	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
 	$(INSTALL_DATA) $(BEHAVIOUR_TARGET_FILES) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
  # 	$(INSTALL_DIR) "$(RELSYSDIR)/include"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/misc/Makefile otp-24.0-patched/lib/snmp/src/misc/Makefile
---- otp-24.0/lib/snmp/src/misc/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-24.0-patched/lib/snmp/src/misc/Makefile	2019-05-28 00:10:06.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/misc/Makefile otp-src-patched/lib/snmp/src/misc/Makefile
+--- otp-src/lib/snmp/src/misc/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-src-patched/lib/snmp/src/misc/Makefile	2019-05-28 00:10:06.000000000 +0100
 @@ -125,7 +125,7 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/src"
@@ -273,9 +273,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/misc
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
  # 	$(INSTALL_DIR) "$(RELSYSDIR)/include"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/ssl/src/Makefile otp-24.0-patched/lib/ssl/src/Makefile
---- otp-24.0/lib/ssl/src/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-24.0-patched/lib/ssl/src/Makefile	2019-05-28 00:10:30.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/ssl/src/Makefile otp-src-patched/lib/ssl/src/Makefile
+--- otp-src/lib/ssl/src/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-src-patched/lib/ssl/src/Makefile	2019-05-28 00:10:30.000000000 +0100
 @@ -207,7 +207,7 @@
 
  release_spec: opt
@@ -285,9 +285,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/ssl/src/Makef
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(BEHAVIOUR_TARGET_FILES) $(TARGET_FILES) $(APP_TARGET) \
  	$(APPUP_TARGET) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/stdlib/src/Makefile otp-24.0-patched/lib/stdlib/src/Makefile
---- otp-24.0/lib/stdlib/src/Makefile	2021-05-12 21:31:57.000000000 +0100
-+++ otp-24.0-patched/lib/stdlib/src/Makefile	2019-05-28 00:10:57.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/stdlib/src/Makefile otp-src-patched/lib/stdlib/src/Makefile
+--- otp-src/lib/stdlib/src/Makefile	2021-05-12 21:31:57.000000000 +0100
++++ otp-src-patched/lib/stdlib/src/Makefile	2019-05-28 00:10:57.000000000 +0100
 @@ -221,7 +221,6 @@
 
  release_spec: opt
@@ -296,9 +296,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/stdlib/src/Ma
  	$(INSTALL_DATA) $(INTERNAL_HRL_FILES) "$(RELSYSDIR)/src"
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)/include"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/syntax_tools/src/Makefile otp-24.0-patched/lib/syntax_tools/src/Makefile
---- otp-24.0/lib/syntax_tools/src/Makefile	2021-05-12 21:31:56.000000000 +0100
-+++ otp-24.0-patched/lib/syntax_tools/src/Makefile	2019-05-28 00:11:32.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/syntax_tools/src/Makefile otp-src-patched/lib/syntax_tools/src/Makefile
+--- otp-src/lib/syntax_tools/src/Makefile	2021-05-12 21:31:56.000000000 +0100
++++ otp-src-patched/lib/syntax_tools/src/Makefile	2019-05-28 00:11:32.000000000 +0100
 @@ -96,8 +96,6 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
@@ -308,9 +308,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/syntax_tools/
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(INCLUDE_DELIVERABLES) "$(RELSYSDIR)/include"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/tools/src/Makefile otp-24.0-patched/lib/tools/src/Makefile
---- otp-24.0/lib/tools/src/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-24.0-patched/lib/tools/src/Makefile	2019-05-28 00:11:51.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/tools/src/Makefile otp-src-patched/lib/tools/src/Makefile
+--- otp-src/lib/tools/src/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-src-patched/lib/tools/src/Makefile	2019-05-28 00:11:51.000000000 +0100
 @@ -109,7 +109,7 @@
 
  release_spec: opt
@@ -320,9 +320,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/tools/src/Mak
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(APP_TARGET) $(APPUP_TARGET) \
  		"$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/xmerl/src/Makefile otp-24.0-patched/lib/xmerl/src/Makefile
---- otp-24.0/lib/xmerl/src/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-24.0-patched/lib/xmerl/src/Makefile	2019-05-28 00:12:38.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/xmerl/src/Makefile otp-src-patched/lib/xmerl/src/Makefile
+--- otp-src/lib/xmerl/src/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-src-patched/lib/xmerl/src/Makefile	2019-05-28 00:12:38.000000000 +0100
 @@ -218,9 +218,7 @@
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"

--- a/otp-0003-Do-not-install-erlang-sources.patch
+++ b/otp-0003-Do-not-install-erlang-sources.patch
@@ -1,6 +1,6 @@
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/asn1/src/Makefile otp-src-patched/lib/asn1/src/Makefile
---- otp-src/lib/asn1/src/Makefile	2021-05-12 21:31:53.000000000 +0100
-+++ otp-src-patched/lib/asn1/src/Makefile	2020-05-13 23:51:34.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/asn1/src/Makefile otp-24.0-patched/lib/asn1/src/Makefile
+--- otp-24.0/lib/asn1/src/Makefile	2021-05-12 21:31:53.000000000 +0100
++++ otp-24.0-patched/lib/asn1/src/Makefile	2020-05-13 23:51:34.000000000 +0100
 @@ -151,7 +151,7 @@
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(APP_TARGET) $(APPUP_TARGET) "$(RELSYSDIR)/ebin"
@@ -10,9 +10,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/asn1/src/Makef
  	$(INSTALL_DIR) "$(RELSYSDIR)/examples"
  	$(INSTALL_DATA) $(EXAMPLES) "$(RELSYSDIR)/examples"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/compiler/src/Makefile otp-src-patched/lib/compiler/src/Makefile
---- otp-src/lib/compiler/src/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-src-patched/lib/compiler/src/Makefile	2020-05-13 23:52:23.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/compiler/src/Makefile otp-24.0-patched/lib/compiler/src/Makefile
+--- otp-24.0/lib/compiler/src/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-24.0-patched/lib/compiler/src/Makefile	2020-05-13 23:52:23.000000000 +0100
 @@ -182,8 +182,8 @@
 
  release_spec: opt
@@ -24,9 +24,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/compiler/src/M
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(INSTALL_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/crypto/src/Makefile otp-src-patched/lib/crypto/src/Makefile
---- otp-src/lib/crypto/src/Makefile	2021-05-12 21:31:53.000000000 +0100
-+++ otp-src-patched/lib/crypto/src/Makefile	2020-05-13 23:52:42.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/crypto/src/Makefile otp-24.0-patched/lib/crypto/src/Makefile
+--- otp-24.0/lib/crypto/src/Makefile	2021-05-12 21:31:53.000000000 +0100
++++ otp-24.0-patched/lib/crypto/src/Makefile	2020-05-13 23:52:42.000000000 +0100
 @@ -81,8 +81,6 @@
  include $(ERL_TOP)/make/otp_release_targets.mk
 
@@ -36,9 +36,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/crypto/src/Mak
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(APP_TARGET) \
  		$(APPUP_TARGET) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/debugger/src/Makefile otp-src-patched/lib/debugger/src/Makefile
---- otp-src/lib/debugger/src/Makefile	2021-05-12 21:31:57.000000000 +0100
-+++ otp-src-patched/lib/debugger/src/Makefile	2020-05-13 23:53:33.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/debugger/src/Makefile otp-24.0-patched/lib/debugger/src/Makefile
+--- otp-24.0/lib/debugger/src/Makefile	2021-05-12 21:31:57.000000000 +0100
++++ otp-24.0-patched/lib/debugger/src/Makefile	2020-05-13 23:53:33.000000000 +0100
 @@ -117,7 +117,7 @@
 
  release_spec: opt
@@ -48,9 +48,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/debugger/src/M
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(TARGET_TOOLBOX_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/edoc/src/Makefile otp-src-patched/lib/edoc/src/Makefile
---- otp-src/lib/edoc/src/Makefile	2021-05-12 21:31:56.000000000 +0100
-+++ otp-src-patched/lib/edoc/src/Makefile	2020-05-13 23:54:07.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/edoc/src/Makefile otp-24.0-patched/lib/edoc/src/Makefile
+--- otp-24.0/lib/edoc/src/Makefile	2021-05-12 21:31:56.000000000 +0100
++++ otp-24.0-patched/lib/edoc/src/Makefile	2020-05-13 23:54:07.000000000 +0100
 @@ -87,7 +87,6 @@
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(OBJECTS) "$(RELSYSDIR)/ebin"
@@ -60,9 +60,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/edoc/src/Makef
 
  release_docs_spec:
 -
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/erl_docgen/src/Makefile otp-src-patched/lib/erl_docgen/src/Makefile
---- otp-src/lib/erl_docgen/src/Makefile	2021-05-12 21:31:55.000000000 +0100
-+++ otp-src-patched/lib/erl_docgen/src/Makefile	2020-05-13 23:54:26.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/erl_docgen/src/Makefile otp-24.0-patched/lib/erl_docgen/src/Makefile
+--- otp-24.0/lib/erl_docgen/src/Makefile	2021-05-12 21:31:55.000000000 +0100
++++ otp-24.0-patched/lib/erl_docgen/src/Makefile	2020-05-13 23:54:26.000000000 +0100
 @@ -91,8 +91,6 @@
  include $(ERL_TOP)/make/otp_release_targets.mk
 
@@ -72,9 +72,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/erl_docgen/src
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/http_client/Makefile otp-src-patched/lib/inets/src/http_client/Makefile
---- otp-src/lib/inets/src/http_client/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-src-patched/lib/inets/src/http_client/Makefile	2019-05-28 00:02:47.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/http_client/Makefile otp-24.0-patched/lib/inets/src/http_client/Makefile
+--- otp-24.0/lib/inets/src/http_client/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-24.0-patched/lib/inets/src/http_client/Makefile	2019-05-28 00:02:47.000000000 +0100
 @@ -92,7 +92,7 @@
  release_spec: opt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/src"
@@ -84,9 +84,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/http
  	$(INSTALL_DIR)  "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/http_lib/Makefile otp-src-patched/lib/inets/src/http_lib/Makefile
---- otp-src/lib/inets/src/http_lib/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-src-patched/lib/inets/src/http_lib/Makefile	2019-05-28 00:03:10.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/http_lib/Makefile otp-24.0-patched/lib/inets/src/http_lib/Makefile
+--- otp-24.0/lib/inets/src/http_lib/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-24.0-patched/lib/inets/src/http_lib/Makefile	2019-05-28 00:03:10.000000000 +0100
 @@ -90,7 +90,7 @@
  release_spec: opt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/src"
@@ -96,9 +96,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/http
  	$(INSTALL_DIR)  "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/http_server/Makefile otp-src-patched/lib/inets/src/http_server/Makefile
---- otp-src/lib/inets/src/http_server/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-src-patched/lib/inets/src/http_server/Makefile	2019-05-28 00:03:32.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/http_server/Makefile otp-24.0-patched/lib/inets/src/http_server/Makefile
+--- otp-24.0/lib/inets/src/http_server/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-24.0-patched/lib/inets/src/http_server/Makefile	2019-05-28 00:03:32.000000000 +0100
 @@ -134,7 +134,7 @@
  release_spec: opt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/src"
@@ -108,9 +108,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/http
  	$(INSTALL_DIR)  "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(BEHAVIOUR_TARGET_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/inets_app/Makefile otp-src-patched/lib/inets/src/inets_app/Makefile
---- otp-src/lib/inets/src/inets_app/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-src-patched/lib/inets/src/inets_app/Makefile	2019-05-28 00:03:53.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/inets/src/inets_app/Makefile otp-24.0-patched/lib/inets/src/inets_app/Makefile
+--- otp-24.0/lib/inets/src/inets_app/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-24.0-patched/lib/inets/src/inets_app/Makefile	2019-05-28 00:03:53.000000000 +0100
 @@ -114,7 +114,7 @@
  release_spec: opt
  	$(INSTALL_DIR)  "$(RELSYSDIR)/src"
@@ -120,9 +120,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/inets/src/inet
  	$(INSTALL_DIR)  "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(EXTERNAL_HRL_FILES) "$(RELSYSDIR)/include"
  	$(INSTALL_DIR)  "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/kernel/src/Makefile otp-src-patched/lib/kernel/src/Makefile
---- otp-src/lib/kernel/src/Makefile	2021-05-12 21:31:59.000000000 +0100
-+++ otp-src-patched/lib/kernel/src/Makefile	2019-05-28 00:04:12.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/kernel/src/Makefile otp-24.0-patched/lib/kernel/src/Makefile
+--- otp-24.0/lib/kernel/src/Makefile	2021-05-12 21:31:59.000000000 +0100
++++ otp-24.0-patched/lib/kernel/src/Makefile	2019-05-28 00:04:12.000000000 +0100
 @@ -228,7 +228,6 @@
 
  release_spec: opt
@@ -131,9 +131,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/kernel/src/Mak
  	$(INSTALL_DATA) $(INTERNAL_HRL_FILES) "$(RELSYSDIR)/src"
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)/include"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/mnesia/src/Makefile otp-src-patched/lib/mnesia/src/Makefile
---- otp-src/lib/mnesia/src/Makefile	2021-05-12 21:31:59.000000000 +0100
-+++ otp-src-patched/lib/mnesia/src/Makefile	2019-05-28 00:04:48.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/mnesia/src/Makefile otp-24.0-patched/lib/mnesia/src/Makefile
+--- otp-24.0/lib/mnesia/src/Makefile	2021-05-12 21:31:59.000000000 +0100
++++ otp-24.0-patched/lib/mnesia/src/Makefile	2019-05-28 00:04:48.000000000 +0100
 @@ -135,7 +135,7 @@
 
  release_spec: opt
@@ -143,9 +143,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/mnesia/src/Mak
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/os_mon/src/Makefile otp-src-patched/lib/os_mon/src/Makefile
---- otp-src/lib/os_mon/src/Makefile	2021-05-12 21:31:55.000000000 +0100
-+++ otp-src-patched/lib/os_mon/src/Makefile	2019-05-28 00:05:12.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/os_mon/src/Makefile otp-24.0-patched/lib/os_mon/src/Makefile
+--- otp-24.0/lib/os_mon/src/Makefile	2021-05-12 21:31:55.000000000 +0100
++++ otp-24.0-patched/lib/os_mon/src/Makefile	2019-05-28 00:05:12.000000000 +0100
 @@ -95,7 +95,6 @@
 
  release_spec: opt
@@ -154,9 +154,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/os_mon/src/Mak
  	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)/src"
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/parsetools/src/Makefile otp-src-patched/lib/parsetools/src/Makefile
---- otp-src/lib/parsetools/src/Makefile	2021-05-12 21:31:58.000000000 +0100
-+++ otp-src-patched/lib/parsetools/src/Makefile	2019-05-28 00:05:52.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/parsetools/src/Makefile otp-24.0-patched/lib/parsetools/src/Makefile
+--- otp-24.0/lib/parsetools/src/Makefile	2021-05-12 21:31:58.000000000 +0100
++++ otp-24.0-patched/lib/parsetools/src/Makefile	2019-05-28 00:05:52.000000000 +0100
 @@ -91,8 +91,6 @@
  include $(ERL_TOP)/make/otp_release_targets.mk
 
@@ -166,9 +166,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/parsetools/src
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/public_key/src/Makefile otp-src-patched/lib/public_key/src/Makefile
---- otp-src/lib/public_key/src/Makefile	2021-05-12 21:31:57.000000000 +0100
-+++ otp-src-patched/lib/public_key/src/Makefile	2019-05-28 00:06:31.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/public_key/src/Makefile otp-24.0-patched/lib/public_key/src/Makefile
+--- otp-24.0/lib/public_key/src/Makefile	2021-05-12 21:31:57.000000000 +0100
++++ otp-24.0-patched/lib/public_key/src/Makefile	2019-05-28 00:06:31.000000000 +0100
 @@ -110,8 +108,6 @@
  include $(ERL_TOP)/make/otp_release_targets.mk
 
@@ -178,9 +178,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/public_key/src
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)/include"
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/reltool/src/Makefile otp-src-patched/lib/reltool/src/Makefile
---- otp-src/lib/reltool/src/Makefile	2021-05-12 21:31:57.000000000 +0100
-+++ otp-src-patched/lib/reltool/src/Makefile	2019-05-28 00:07:05.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/reltool/src/Makefile otp-24.0-patched/lib/reltool/src/Makefile
+--- otp-24.0/lib/reltool/src/Makefile	2021-05-12 21:31:57.000000000 +0100
++++ otp-24.0-patched/lib/reltool/src/Makefile	2019-05-28 00:07:05.000000000 +0100
 @@ -100,7 +100,7 @@
 
  release_spec: opt
@@ -190,9 +190,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/reltool/src/Ma
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(APP_TARGET) $(APPUP_TARGET) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/runtime_tools/src/Makefile otp-src-patched/lib/runtime_tools/src/Makefile
---- otp-src/lib/runtime_tools/src/Makefile	2021-05-12 21:31:55.000000000 +0100
-+++ otp-src-patched/lib/runtime_tools/src/Makefile	2019-05-28 00:07:27.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/runtime_tools/src/Makefile otp-24.0-patched/lib/runtime_tools/src/Makefile
+--- otp-24.0/lib/runtime_tools/src/Makefile	2021-05-12 21:31:55.000000000 +0100
++++ otp-24.0-patched/lib/runtime_tools/src/Makefile	2019-05-28 00:07:27.000000000 +0100
 @@ -99,8 +99,6 @@
  include $(ERL_TOP)/make/otp_release_targets.mk
 
@@ -202,9 +202,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/runtime_tools/
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)/include"
  	$(INSTALL_DIR) "$(RELSYSDIR)/examples"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/sasl/src/Makefile otp-src-patched/lib/sasl/src/Makefile
---- otp-src/lib/sasl/src/Makefile	2021-05-12 21:31:55.000000000 +0100
-+++ otp-src-patched/lib/sasl/src/Makefile	2019-05-28 00:07:59.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/sasl/src/Makefile otp-24.0-patched/lib/sasl/src/Makefile
+--- otp-24.0/lib/sasl/src/Makefile	2021-05-12 21:31:55.000000000 +0100
++++ otp-24.0-patched/lib/sasl/src/Makefile	2019-05-28 00:07:59.000000000 +0100
 @@ -94,7 +94,6 @@
 
  release_spec: opt
@@ -213,10 +213,10 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/sasl/src/Makef
  	$(INSTALL_DATA) $(INTERNAL_HRL_FILES) "$(RELSYSDIR)/src"
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/agent/Makefile.in otp-src-patched/lib/snmp/src/agent/Makefile.in
---- otp-src/lib/snmp/src/agent/Makefile.in	2021-05-12 21:31:54.000000000 +0100
-+++ otp-src-patched/lib/snmp/src/agent/Makefile.in	2019-05-28 00:08:21.000000000 +0100
-@@ -161,7 +161,7 @@
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/agent/Makefile otp-24.0-patched/lib/snmp/src/agent/Makefile
+--- otp-24.0/lib/snmp/src/agent/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-24.0-patched/lib/snmp/src/agent/Makefile	2019-05-28 00:08:21.000000000 +0100
+@@ -151,7 +151,7 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/src"
  	$(INSTALL_DIR) "$(RELSYSDIR)/src/agent"
@@ -225,9 +225,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/agent
 	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
 	$(INSTALL_DATA) $(BEHAVIOUR_TARGET_FILES) $(TARGET_FILES) $(APP_TARGET) $(APPUP_TARGET) \
 		"$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/app/Makefile otp-src-patched/lib/snmp/src/app/Makefile
---- otp-src/lib/snmp/src/app/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-src-patched/lib/snmp/src/app/Makefile	2019-05-28 00:08:48.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/app/Makefile otp-24.0-patched/lib/snmp/src/app/Makefile
+--- otp-24.0/lib/snmp/src/app/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-24.0-patched/lib/snmp/src/app/Makefile	2019-05-28 00:08:48.000000000 +0100
 @@ -144,7 +144,7 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/src"
@@ -237,9 +237,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/app/M
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(APP_TARGET) $(APPUP_TARGET) \
  		"$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/compile/Makefile otp-src-patched/lib/snmp/src/compile/Makefile
---- otp-src/lib/snmp/src/compile/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-src-patched/lib/snmp/src/compile/Makefile	2019-05-28 00:09:19.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/compile/Makefile otp-24.0-patched/lib/snmp/src/compile/Makefile
+--- otp-24.0/lib/snmp/src/compile/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-24.0-patched/lib/snmp/src/compile/Makefile	2019-05-28 00:09:19.000000000 +0100
 @@ -137,7 +137,7 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/src"
@@ -249,9 +249,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/compi
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(EBIN_FILES) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DIR) "$(RELSYSDIR)/bin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/manager/Makefile otp-src-patched/lib/snmp/src/manager/Makefile
---- otp-src/lib/snmp/src/manager/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-src-patched/lib/snmp/src/manager/Makefile	2019-05-28 00:09:43.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/manager/Makefile otp-24.0-patched/lib/snmp/src/manager/Makefile
+--- otp-24.0/lib/snmp/src/manager/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-24.0-patched/lib/snmp/src/manager/Makefile	2019-05-28 00:09:43.000000000 +0100
 @@ -135,7 +135,7 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/src"
@@ -261,9 +261,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/manag
 	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
 	$(INSTALL_DATA) $(BEHAVIOUR_TARGET_FILES) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
  # 	$(INSTALL_DIR) "$(RELSYSDIR)/include"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/misc/Makefile otp-src-patched/lib/snmp/src/misc/Makefile
---- otp-src/lib/snmp/src/misc/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-src-patched/lib/snmp/src/misc/Makefile	2019-05-28 00:10:06.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/snmp/src/misc/Makefile otp-24.0-patched/lib/snmp/src/misc/Makefile
+--- otp-24.0/lib/snmp/src/misc/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-24.0-patched/lib/snmp/src/misc/Makefile	2019-05-28 00:10:06.000000000 +0100
 @@ -125,7 +125,7 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/src"
@@ -273,9 +273,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/snmp/src/misc/
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
  # 	$(INSTALL_DIR) "$(RELSYSDIR)/include"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/ssl/src/Makefile otp-src-patched/lib/ssl/src/Makefile
---- otp-src/lib/ssl/src/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-src-patched/lib/ssl/src/Makefile	2019-05-28 00:10:30.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/ssl/src/Makefile otp-24.0-patched/lib/ssl/src/Makefile
+--- otp-24.0/lib/ssl/src/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-24.0-patched/lib/ssl/src/Makefile	2019-05-28 00:10:30.000000000 +0100
 @@ -207,7 +207,7 @@
 
  release_spec: opt
@@ -285,9 +285,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/ssl/src/Makefi
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(BEHAVIOUR_TARGET_FILES) $(TARGET_FILES) $(APP_TARGET) \
  	$(APPUP_TARGET) "$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/stdlib/src/Makefile otp-src-patched/lib/stdlib/src/Makefile
---- otp-src/lib/stdlib/src/Makefile	2021-05-12 21:31:57.000000000 +0100
-+++ otp-src-patched/lib/stdlib/src/Makefile	2019-05-28 00:10:57.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/stdlib/src/Makefile otp-24.0-patched/lib/stdlib/src/Makefile
+--- otp-24.0/lib/stdlib/src/Makefile	2021-05-12 21:31:57.000000000 +0100
++++ otp-24.0-patched/lib/stdlib/src/Makefile	2019-05-28 00:10:57.000000000 +0100
 @@ -221,7 +221,6 @@
 
  release_spec: opt
@@ -296,9 +296,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/stdlib/src/Mak
  	$(INSTALL_DATA) $(INTERNAL_HRL_FILES) "$(RELSYSDIR)/src"
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)/include"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/syntax_tools/src/Makefile otp-src-patched/lib/syntax_tools/src/Makefile
---- otp-src/lib/syntax_tools/src/Makefile	2021-05-12 21:31:56.000000000 +0100
-+++ otp-src-patched/lib/syntax_tools/src/Makefile	2019-05-28 00:11:32.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/syntax_tools/src/Makefile otp-24.0-patched/lib/syntax_tools/src/Makefile
+--- otp-24.0/lib/syntax_tools/src/Makefile	2021-05-12 21:31:56.000000000 +0100
++++ otp-24.0-patched/lib/syntax_tools/src/Makefile	2019-05-28 00:11:32.000000000 +0100
 @@ -96,8 +96,6 @@
  release_spec: opt
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
@@ -308,9 +308,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/syntax_tools/s
  	$(INSTALL_DIR) "$(RELSYSDIR)/include"
  	$(INSTALL_DATA) $(INCLUDE_DELIVERABLES) "$(RELSYSDIR)/include"
 
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/tools/src/Makefile otp-src-patched/lib/tools/src/Makefile
---- otp-src/lib/tools/src/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-src-patched/lib/tools/src/Makefile	2019-05-28 00:11:51.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/tools/src/Makefile otp-24.0-patched/lib/tools/src/Makefile
+--- otp-24.0/lib/tools/src/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-24.0-patched/lib/tools/src/Makefile	2019-05-28 00:11:51.000000000 +0100
 @@ -109,7 +109,7 @@
 
  release_spec: opt
@@ -320,9 +320,9 @@ diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/tools/src/Make
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) $(APP_TARGET) $(APPUP_TARGET) \
  		"$(RELSYSDIR)/ebin"
-diff --ignore-blank-lines --ignore-space-change -u -r otp-src/lib/xmerl/src/Makefile otp-src-patched/lib/xmerl/src/Makefile
---- otp-src/lib/xmerl/src/Makefile	2021-05-12 21:31:54.000000000 +0100
-+++ otp-src-patched/lib/xmerl/src/Makefile	2019-05-28 00:12:38.000000000 +0100
+diff --ignore-blank-lines --ignore-space-change -u -r otp-24.0/lib/xmerl/src/Makefile otp-24.0-patched/lib/xmerl/src/Makefile
+--- otp-24.0/lib/xmerl/src/Makefile	2021-05-12 21:31:54.000000000 +0100
++++ otp-24.0-patched/lib/xmerl/src/Makefile	2019-05-28 00:12:38.000000000 +0100
 @@ -218,9 +218,7 @@
  	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
  	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"


### PR DESCRIPTION
So that we can support more distribution and even (local) aarch64 builds for Erlang 24.