### PR TITLE
Build packages for EL9 out of Rocky 9

### DIFF
--- a/docker/build-packages.sh
+++ b/docker/build-packages.sh
@@ -12,7 +12,7 @@ build_and_fetch_rpm_for() {
 
 # These cover CentOS Stream, Rocky Linux, Alma Linux, Oracle Linux
 # of the same respective version
-build_and_fetch_rpm_for "stream9"
+build_and_fetch_rpm_for "rocky9"
 build_and_fetch_rpm_for "stream8"
 # These distributions cannot use CentOS Stream packages
 build_and_fetch_rpm_for "al2023"


### PR DESCRIPTION
CentOS Stgream 9 is not a correct target against which one may or should build packages compatible with EL and it's derivatives.

CentOS Stream regularly introduces changes that are not yet available in stable EL distributions, making resulting packages incompatible with EL. At the same time, packages built against EL9 or it's derivatives will be compatible with CentOS Stream.

With that it is suggested to switch building to Rocky 9 from CentOS Stream 9, as remaining scripts in the repo seem to be compatible with Rocky 9 as contain logic for it.

Closes-Bug: #131