### PR TITLE
Refactoring to avoid the need for `sudo` (for the `erlang-28` branch)

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,4 +1,5 @@
-build-dir-*/*
-docker-*/*
-pkg-build-dir/*
-all_rpms/*
+all_rpms/
+docker-*/
+pkg-build-dir/
+pkg-build-dir.*/
+tarballs/

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -1,14 +1,30 @@
 ARG image
 ARG image_tag
 
-FROM $image:$image_tag
+FROM ${image}:${image_tag}
 
-RUN yum install dnf -y
-RUN dnf -y update && dnf clean all
+# Some older base images (RHEL/CentOS 8) ship yum but not dnf.
+RUN command -v dnf >/dev/null 2>&1 || yum install -y dnf
 
-RUN dnf install -y autoconf clang m4 openssl-devel ncurses-devel rpm-build rpmdevtools tar wget zlib-devel systemd-devel make sudo
-RUN dnf install -y rpmlint || true
+RUN dnf -y update \
+ && dnf -y install \
+        autoconf \
+        clang \
+        m4 \
+        make \
+        ncurses-devel \
+        openssl-devel \
+        rpm-build \
+        rpmdevtools \
+        systemd-devel \
+        tar \
+        wget \
+        zlib-devel \
+ && (dnf -y install rpmlint || true) \
+ && dnf clean all \
+ && rm -rf /var/cache/dnf
 
-RUN mkdir /build
+RUN mkdir -p /build/pkg-build-dir
 WORKDIR /build/pkg-build-dir
-CMD ["sh", "-c", "make"]
+
+CMD ["make"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,84 +1,62 @@
 # Docker Build Environment
 
-This directory contains tooling that sets up a Docker image which can be used to build
-several flavors (varieties) of the zero-dependency Erlang RPM.
+This directory contains tooling that builds the zero-dependency
+Erlang RPM inside an OCI image, for several RPM-based distributions.
 
-Run
+The scripts work on macOS (Docker Desktop, Podman, OrbStack, ...) and
+on RPM-based Linux distributions with any Docker-compatible daemon.
+None of them require `sudo`: configure your daemon for rootless use,
+or add your user to the appropriate group.
 
-``` bash
-# builds a Docker image for building the RHEL 9/CentOS Stream 9 version
-# of the RPM
-./build-docker-image.sh stream9 --no-cache
-```
-
-to build a RHEL 9/CentOS Stream 9 Docker image with all the build dependencies installed.
-
-Having this image, we can proceed to building an actual zero-dependency Erlang RPM.
-
-## Building the RPM
+## Quick Start
 
 ``` bash
-# builds a RHEL 9 and CentOS Stream 9 flavor of the package
-./build-rpm-in-docker.sh stream9
+# Build the OCI image for RHEL/Rocky/Alma/Oracle 9.x
+./build-docker-image.sh 9
+
+# Build the RPM inside it
+./build-rpm-in-docker.sh 9
 ```
 
-to do the build. This will create a directory `all_rpms` in this
-directory; the built RPMs will be copied there.
-
-## Building Different Image Flavors
-
-It is possible to build the RPM on and for a number of RPM-based operating systems:
+The two steps can also be chained:
 
 ``` bash
-# for RHEL 9 and CentOS Stream 9
-./build-image-and-rpm.sh stream9 --no-cache
+./build-image-and-rpm.sh 9
 ```
 
-``` bash
-# builds an Amazon Linux 2023 flavor of the package
-./build-rpm-in-docker.sh al2023
-```
+Built RPMs are copied to `./all_rpms`.
 
-``` bash
-# builds a Fedora 38 flavor of the package
-./build-rpm-in-docker.sh fc38
-```
+## Supported Flavors
 
-``` bash
-# builds a Fedora 39 flavor of the package
-./build-rpm-in-docker.sh fc39
-```
+| Flavor                              | Distributions                                          |
+|-------------------------------------|--------------------------------------------------------|
+| `10` / `stream10` / `centos10`      | RHEL, Rocky, Alma, Oracle Linux 10.x                   |
+| `9`  / `stream9`  / `centos9`       | RHEL, Rocky, Alma, Oracle Linux 9.x                    |
+| `8`  / `stream8`  / `centos8`       | RHEL, Rocky, Alma, Oracle Linux 8.x                    |
+| `rocky10` / `rocky9` / `rocky8`     | Rocky Linux                                            |
+| `alma10`  / `alma9`                 | AlmaLinux                                              |
+| `oracle10` / `oracle9`              | Oracle Linux                                           |
+| `al2023`                            | Amazon Linux 2023                                      |
+| `fc42` / `fc41`                     | Fedora                                                 |
 
-``` bash
-# builds a Rocky Linux 9 flavor of the package
-./build-rpm-in-docker.sh rocky
-```
-
-``` bash
-# builds an Alma Linux 9 flavor of the package
-./build-rpm-in-docker.sh alma
-```
-
-``` bash
-# builds an Oracle Linux 9 flavor of the package
-./build-rpm-in-docker.sh oracle
-```
-
-The commands assume that the image for the targeted distribution was built (see the earlier step).
-
-Built RPMs can be found under `./pkg-build-dir/RPMS/{architecture}`.
-
-## Building All Flavors
+## Building Every Flavor
 
 ``` bash
 ./build-packages.sh
 ```
 
-will produce a number of packages for the most popular distributions (in the RabbitMQ community):
+builds the package for every flavor we ship today and drops the
+results into `./all_rpms`.
 
- * RHEL 9 and CentOS Stream 9 (including Rocky Linux 9, Alma Linux 9, Oracle Linux 9)
- * RHEL 8 and CentOS Stream 8
- * Amazon Linux 2023
- * Fedora 38
+## Tarball Cache
 
-Built RPMs will be copied to the `./all_rpms` directory under `docker`.
+The upstream Erlang/OTP source tarball is downloaded **once** into
+`./tarballs` and reused across every flavor and every subsequent run.
+Delete the file (or the directory) to force a re-download.
+
+## Transient Build Directories
+
+Each invocation of `build-rpm-in-docker.sh` stages its inputs in a
+fresh `pkg-build-dir.XXXXXX` directory and removes it on exit (even
+on failure or interrupt). The container chowns the artifacts back to
+the invoking host user before exiting, so cleanup never needs `sudo`.

--- a/docker/build-docker-image.sh
+++ b/docker/build-docker-image.sh
@@ -1,80 +1,58 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+# Build the OCI image used to produce the zero-dependency Erlang RPM
+# for one RPM-based distribution flavor. Works with docker or podman
+# on macOS and on RPM-based Linux. No sudo.
 
-os_name="$1"
-docker_params=${2:-"--pull"}
-dockerfile="Dockerfile.template"
+set -euo pipefail
 
-case $os_name in
-	fedora|f42|fc42|fedora42)
-		image="fedora"
-		image_tag="42";;
-	f41|fc41|fedora41)
-		image="fedora"
-		image_tag="41";;
-	al|al2023|amazonlinux2023)
-		image="amazonlinux"
-		image_tag="2023";;
-	oracle10|oraclelinux10)
-		image="oraclelinux"
-		image_tag="10";;
-	oracle|oracle9|oraclelinux9)
-		image="oraclelinux"
-		image_tag="9";;
-	rocky10|rockylinux10)
-		image="rockylinux/rockylinux"
-		image_tag="10";;
-	rocky|rocky9|rockylinux9)
-		image="rockylinux/rockylinux"
-		image_tag="9";;
-	rocky|rocky8|rockylinux8)
-		image="rockylinux/rockylinux"
-		image_tag="8";;
-	alma10|almalinux10)
-		image="almalinux"
-		image_tag="10";;
-	alma|alma9|almalinux9)
-		image="almalinux"
-		image_tag="9";;
-	10|stream10|centos10)
-		image="quay.io/centos/centos"
-		image_tag=stream10;;
-	9|stream9|centos9)
-		image="quay.io/centos/centos"
-		image_tag=stream9;;
-	8|stream8|centos8)
-		image="rockylinux"
-		image_tag=8;;
+# shellcheck source=common.sh
+. "$(dirname "$0")/common.sh"
+
+usage() {
+	cat >&2 <<'EOF'
+Usage: build-docker-image.sh <flavor> [extra build args...]
+
+Flavors: 10|stream10  9|stream9  8|stream8
+         rocky10|rocky9|rocky8  alma10|alma9
+         oracle10|oracle9  al2023  fc42|fc41
+EOF
+	exit 1
+}
+
+[[ $# -ge 1 ]] || usage
+flavor=$1; shift
+extra_args=("$@")
+
+case $flavor in
+	fedora|f42|fc42|fedora42)        image="fedora";                tag="42" ;;
+	f41|fc41|fedora41)               image="fedora";                tag="41" ;;
+	al|al2023|amazonlinux2023)       image="amazonlinux";           tag="2023" ;;
+	oracle10|oraclelinux10)          image="oraclelinux";           tag="10" ;;
+	oracle|oracle9|oraclelinux9)     image="oraclelinux";           tag="9" ;;
+	rocky10|rockylinux10)            image="rockylinux/rockylinux"; tag="10" ;;
+	rocky|rocky9|rockylinux9)        image="rockylinux/rockylinux"; tag="9" ;;
+	rocky8|rockylinux8)              image="rockylinux/rockylinux"; tag="8" ;;
+	alma10|almalinux10)              image="almalinux";             tag="10" ;;
+	alma|alma9|almalinux9)           image="almalinux";             tag="9" ;;
+	10|stream10|centos10)            image="quay.io/centos/centos"; tag="stream10" ;;
+	9|stream9|centos9)               image="quay.io/centos/centos"; tag="stream9" ;;
+	8|stream8|centos8)               image="rockylinux";            tag="8" ;;
+	*) echo "Unknown flavor: $flavor" >&2; usage ;;
 esac
 
-docker_dir="docker-$os_name"
+cd "$(dirname "$0")"
 
-if [ -z "$os_name" ]
-then
-	echo "
-This script takes two arguments.
-first: distribution, one of stream10, stream9, stream8, al2023, fedora, rocky, alma, oracle
-second: docker build parameters such as --no-cache
------------------------------------------
-Ex: ./build-docker-image.sh stream9 --no-cache
-Ex: ./build-docker-image.sh stream8 --no-cache
-Ex: ./build-docker-image.sh fedora38 --no-cache
-"
-exit 1
-fi
+engine=$(detect_engine)
+image_tag="erlang-rpm-build-$flavor"
 
-if [ -e "$docker_dir" ]
-then
-	rm -rf "$docker_dir"
-fi
+echo "==> [$engine] Building image '$image_tag' from ${image}:${tag}"
 
-mkdir "$docker_dir"
-
-echo "Will build an image for ${image}:${image_tag} using Docker file at $docker_dir/Dockerfile"
-
-cp "$dockerfile" "$docker_dir/Dockerfile"
-	case $(uname -s) in
-		Linux)
-			sudo docker build --build-arg image="$image" --build-arg image_tag="$image_tag" "$docker_params" -t="erlang-rpm-build-$os_name" "$docker_dir";;
-		*)
-			docker build --build-arg image="$image" --build-arg image_tag="$image_tag" "$docker_params" -t="erlang-rpm-build-$os_name" "$docker_dir";;
-	esac
+# Stream the Dockerfile via stdin so the build has an empty context
+# (no tarballs, RPMs, or transient build dirs get sent to the daemon).
+"$engine" build \
+	--pull \
+	--build-arg "image=$image" \
+	--build-arg "image_tag=$tag" \
+	-t "$image_tag" \
+	${extra_args[@]+"${extra_args[@]}"} \
+	- < Dockerfile.template

--- a/docker/build-image-and-rpm.sh
+++ b/docker/build-image-and-rpm.sh
@@ -1,23 +1,12 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+# Convenience: build the image for a flavor, then build the RPM in it.
+set -euo pipefail
 
-usage() {
-	echo "
-This script takes two arguments.
-first: distribution, one of rocky9, alma9, rocky8, stream10, al2023, fedora, oracle
-second: docker build parameters such as --no-cache
------------------------------------------
-Ex: ./build-image-and-rpm.sh rocky9 --no-cache
-Ex: ./build-image-and-rpm.sh rocky9 --no-cache
-Ex: ./build-image-and-rpm.sh fedora41 --no-cache
-"
-  exit 1
-}
-
-
-if [ $# -lt 1 ]
-then
-  usage
+if [[ $# -lt 1 ]]; then
+	echo "Usage: build-image-and-rpm.sh <flavor> [extra docker build args...]" >&2
+	exit 1
 fi
 
-./build-docker-image.sh "$1" "$2"
+cd "$(dirname "$0")"
+./build-docker-image.sh "$@"
 ./build-rpm-in-docker.sh "$1"

--- a/docker/build-packages.sh
+++ b/docker/build-packages.sh
@@ -1,21 +1,26 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+# Build the zero-dependency Erlang RPM for every shipped flavor.
+# The OTP source tarball is downloaded once and reused across flavors.
 
-all_rpms_dir="all_rpms"
+set -euo pipefail
 
-mkdir -p "$all_rpms_dir"
+cd "$(dirname "$0")"
 
-build_and_fetch_rpm_for() {
-  distribution=$1
-  ./build-image-and-rpm.sh "$distribution"
-  cp pkg-build-dir/RPMS/*/erlang-* "$all_rpms_dir"
-}
+flavors=(
+	rocky10
+	rocky9
+	rocky8
+	al2023
+	fedora42
+)
 
-# These cover CentOS Stream, Rocky Linux, Alma Linux, Oracle Linux
-# of the same respective version
-build_and_fetch_rpm_for "rocky10"
-build_and_fetch_rpm_for "rocky9"
-build_and_fetch_rpm_for "rocky8"
-# These distributions cannot use CentOS Stream packages
-build_and_fetch_rpm_for "al2023"
-# Fedora 42 ships with Erlang 26.2.x
-build_and_fetch_rpm_for "fedora42"
+for flavor in "${flavors[@]}"; do
+	echo
+	echo "############################################################"
+	echo "# Building flavor: $flavor"
+	echo "############################################################"
+	./build-image-and-rpm.sh "$flavor"
+done
+
+echo
+echo "==> All RPMs available in $PWD/all_rpms"

--- a/docker/build-rpm-in-docker.sh
+++ b/docker/build-rpm-in-docker.sh
@@ -1,47 +1,113 @@
 #!/usr/bin/env bash
+# Build the zero-dependency Erlang RPM inside the OCI image produced
+# by build-docker-image.sh. Reuses a shared upstream tarball cache
+# (./tarballs) across all flavors and runs.
 
-os_name="$1"
+set -euo pipefail
 
-# this has to match what Dockerfile uses
-build_dir="pkg-build-dir"
-pkg_files=("Makefile" "erlang.spec" "Erlang_ASL2_LICENSE.txt")
+# shellcheck source=common.sh
+. "$(dirname "$0")/common.sh"
 
-if [ -z "$os_name" ]
-then
-	echo "
-Ops: parameters error
-first: version or distribution name, ex: stream10, stream9, stream8, f38
------------------------------------------
-Ex: ./build-rpm-in-docker.sh stream9
-Ex: ./build-rpm-in-docker.sh stream8
-"
+usage() {
+	cat >&2 <<'EOF'
+Usage: build-rpm-in-docker.sh <flavor>
+
+Builds the package inside the 'erlang-rpm-build-<flavor>' image
+previously produced by build-docker-image.sh.
+EOF
+	exit 1
+}
+
+[[ $# -ge 1 ]] || usage
+flavor=$1
+
+cd "$(dirname "$0")"
+script_dir=$PWD
+repo_root=$(cd .. && pwd)
+engine=$(detect_engine)
+image_tag="erlang-rpm-build-$flavor"
+
+# Discover OTP version from the top-level Makefile.
+otp_release=$(awk -F= \
+	'/^OTP_RELEASE[[:space:]]*=/ { gsub(/[[:space:]]/, "", $2); print $2; exit }' \
+	"$repo_root/Makefile")
+[[ -n $otp_release ]] || { echo "Could not read OTP_RELEASE from Makefile" >&2; exit 1; }
+
+tarball="OTP-${otp_release}.tar.gz"
+url="https://github.com/erlang/otp/archive/${tarball}"
+
+# Shared cache; one download per OTP version, regardless of flavor.
+cache_dir="$script_dir/tarballs"
+mkdir -p "$cache_dir"
+
+if [[ ! -f "$cache_dir/$tarball" ]]; then
+	echo "==> Downloading $tarball"
+	tmp=$(mktemp "$cache_dir/.${tarball}.XXXXXX")
+	trap 'rm -f "$tmp"' EXIT
+	if command -v curl >/dev/null 2>&1; then
+		curl -fL --retry 3 --output "$tmp" "$url"
+	else
+		wget -O "$tmp" "$url"
+	fi
+	mv "$tmp" "$cache_dir/$tarball"
+	trap - EXIT
+else
+	echo "==> Reusing cached $cache_dir/$tarball"
+fi
+
+# Per-build transient directory; cleaned up on every exit path.
+build_dir=$(mktemp -d "$script_dir/pkg-build-dir.XXXXXX")
+cleanup() {
+	# Fast path: remove as the host user.
+	rm -rf "$build_dir" 2>/dev/null && return
+	# Fallback: files inside may be owned by container root (rootful
+	# docker on Linux), so ask a throwaway container to nuke them.
+	"$engine" run --rm --pull=never \
+		-v "$build_dir:/cleanup:z" \
+		--entrypoint /bin/sh \
+		"$image_tag" \
+		-c 'find /cleanup -mindepth 1 -delete' >/dev/null 2>&1 || true
+	rmdir "$build_dir" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "$build_dir/tarballs" "$build_dir/dist"
+
+# Stage a fresh copy of the cached tarball; the in-container Makefile
+# may delete its working copy, but the shared cache stays intact.
+cp -p "$cache_dir/$tarball" "$build_dir/tarballs/"
+
+cp -p "$repo_root"/Makefile \
+      "$repo_root"/erlang.spec \
+      "$repo_root"/Erlang_ASL2_LICENSE.txt \
+      "$build_dir/"
+cp -p "$repo_root"/*.patch "$build_dir/"
+
+echo "==> [$engine] Building RPM in $build_dir using image '$image_tag'"
+"$engine" run --rm \
+	--pull=never \
+	-v "$build_dir:/build/pkg-build-dir:z" \
+	"$image_tag"
+
+# Collect every produced .rpm into all_rpms/<arch>/. The arch is the
+# component just before the final ".rpm" suffix in the filename.
+out_dir="$script_dir/all_rpms"
+mkdir -p "$out_dir"
+found=0
+while IFS= read -r -d '' rpm; do
+	base=$(basename "$rpm")
+	stem=${base%.rpm}
+	arch=${stem##*.}
+	[[ -n $arch ]] || arch="unknown"
+	mkdir -p "$out_dir/$arch"
+	cp -p "$rpm" "$out_dir/$arch/"
+	chmod 0644 "$out_dir/$arch/$(basename "$rpm")"
+	found=$((found + 1))
+done < <(find "$build_dir" -type f -name '*.rpm' -print0 2>/dev/null)
+
+if (( found == 0 )); then
+	echo "No RPMs were produced; build likely failed." >&2
 	exit 1
 fi
 
-echo "Re-creating build dir $build_dir"
-
-if [ -e "$build_dir" ]
-then
-	rm -rf "$build_dir"
-fi
-
-mkdir "$build_dir"
-mkdir "$build_dir/dist"
-
-echo "Copying patches to build dir $build_dir"
-cp ../*.patch "$build_dir"
-
-echo "Copying other files to build dir $build_dir"
-for file in "${pkg_files[@]}"
-do
-	echo "Will copy ${file} from ../${file}"
-	cp "../${file}" "$build_dir"
-done
-
-echo "Will now build the RPM in '$build_dir' using image 'erlang-rpm-build-$os_name'"
-case $(uname -s) in
-	Linux)
-		sudo docker run --pull=never --dns 8.8.8.8 -i -t -v "$PWD"/"$build_dir":/build/"$build_dir":z "erlang-rpm-build-$os_name";;
-	*)
-		docker run --pull=never --dns 8.8.8.8 -i -t -v "$PWD"/"$build_dir":/build/"$build_dir":z "erlang-rpm-build-$os_name";;
-esac
+echo "==> $found RPM(s) copied to $out_dir"

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for the build scripts in this directory.
+# Sourced, not executed.
+
+# Pick a container engine. Honor $ENGINE if set; otherwise prefer
+# `docker` (which may itself be a `podman`-compatible CLI), then `podman`.
+detect_engine() {
+	if [[ -n ${ENGINE:-} ]]; then
+		printf '%s\n' "$ENGINE"
+		return
+	fi
+	if command -v docker >/dev/null 2>&1; then
+		printf 'docker\n'
+	elif command -v podman >/dev/null 2>&1; then
+		printf 'podman\n'
+	else
+		echo "Neither 'docker' nor 'podman' found in PATH." >&2
+		exit 1
+	fi
+}

--- a/erlang.spec
+++ b/erlang.spec
@@ -235,7 +235,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/erlang/bin/start.boot
 %{_libdir}/erlang/bin/start.script
 %{_libdir}/erlang/bin/start_clean.boot
-%{_libdir}/erlang/bin/start_erl
+# brp-mangle-shebangs rewrites this script via mktemp+rename and ends
+# up clearing its execute bits; force them back here.
+%attr(0755,root,root) %{_libdir}/erlang/bin/start_erl
 %{_libdir}/erlang/bin/start_sasl.boot
 %{_libdir}/erlang/bin/to_erl
 %dir %{_libdir}/erlang/erts-*/bin
@@ -243,17 +245,18 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/erlang/erts-*/bin/erl_child_setup
 %{_libdir}/erlang/erts-*/bin/dyn_erl
 %{_libdir}/erlang/erts-*/bin/epmd
-%{_libdir}/erlang/erts-*/bin/erl
-%{_libdir}/erlang/erts-*/bin/erl.src
+# See note above %{_libdir}/erlang/bin/start_erl about brp-mangle-shebangs.
+%attr(0755,root,root) %{_libdir}/erlang/erts-*/bin/erl
+%attr(0755,root,root) %{_libdir}/erlang/erts-*/bin/erl.src
 %{_libdir}/erlang/erts-*/bin/erlc
 %{_libdir}/erlang/erts-*/bin/erlexec
 %{_libdir}/erlang/erts-*/bin/escript
 %{_libdir}/erlang/erts-*/bin/heart
 %{_libdir}/erlang/erts-*/bin/inet_gethost
 %{_libdir}/erlang/erts-*/bin/run_erl
-%{_libdir}/erlang/erts-*/bin/start
-%{_libdir}/erlang/erts-*/bin/start.src
-%{_libdir}/erlang/erts-*/bin/start_erl.src
+%attr(0755,root,root) %{_libdir}/erlang/erts-*/bin/start
+%attr(0755,root,root) %{_libdir}/erlang/erts-*/bin/start.src
+%attr(0755,root,root) %{_libdir}/erlang/erts-*/bin/start_erl.src
 %{_libdir}/erlang/erts-*/bin/to_erl
 %{_libdir}/erlang/erts-*/include
 %{_libdir}/erlang/erts-*/lib


### PR DESCRIPTION
Unintentioanly from almost the start, the
build part of this project has effectively
mandated the use of `sudo` in this repo.

On top of that, it annoyingly downloads the
sizeable Erlang/OTP tarball multiple times
when a package for N distributions is
built at once.

This refactoring makes both a non-issue
and makes sure our shell scripts pass
`shellcheck`.